### PR TITLE
refactor compression for float

### DIFF
--- a/tachyon_core/src/storage/compression/int/mod.rs
+++ b/tachyon_core/src/storage/compression/int/mod.rs
@@ -1,0 +1,142 @@
+use std::io::{Read, Write};
+
+use crate::{storage::file::Header, Timestamp};
+
+use super::{CompressionEngine, DecompressionEngine};
+
+#[deprecated]
+mod v1;
+mod v2;
+
+pub(super) struct IntCompressionUtils;
+impl IntCompressionUtils {
+    #[inline]
+    pub fn zig_zag_decode(n: u64) -> i64 {
+        ((n >> 1) as i64) ^ -((n & 1) as i64)
+    }
+
+    #[inline]
+    pub fn zig_zag_encode(n: i64) -> u64 {
+        ((n >> (i64::BITS as usize - 1)) ^ (n << 1)) as u64
+    }
+}
+
+// TODO: Make macro to generate the enum + implementation
+#[allow(clippy::large_enum_variant)]
+#[allow(deprecated)]
+pub enum IntDecompressor<R: Read> {
+    V1(v1::DecompressionEngineV1<R>),
+    V2(v2::DecompressionEngineV2<R>),
+}
+
+impl<R: Read> DecompressionEngine<R> for IntDecompressor<R> {
+    type PhysicalType = u64;
+
+    fn new(reader: R, header: &Header) -> Self {
+        Self::V2(v2::DecompressionEngineV2::new(reader, header))
+    }
+
+    fn next(&mut self) -> (Timestamp, u64) {
+        match self {
+            Self::V1(engine) => engine.next(),
+            Self::V2(engine) => engine.next(),
+        }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[allow(deprecated)]
+pub enum IntCompressor<W: Write> {
+    V1(v1::CompressionEngineV1<W>),
+    V2(v2::CompressionEngineV2<W>),
+}
+
+impl<W: Write> CompressionEngine<W> for IntCompressor<W> {
+    type PhysicalType = u64;
+
+    fn new(writer: W, header: &Header) -> Self {
+        Self::V2(v2::CompressionEngineV2::new(writer, header))
+    }
+
+    fn consume(&mut self, timestamp: Timestamp, value: Self::PhysicalType) {
+        match self {
+            Self::V1(engine) => engine.consume(timestamp, value),
+            Self::V2(engine) => engine.consume(timestamp, value),
+        }
+    }
+
+    fn flush_all(&mut self) -> usize {
+        match self {
+            Self::V1(engine) => engine.flush_all(),
+            Self::V2(engine) => engine.flush_all(),
+        }
+    }
+}
+
+#[test]
+fn test_zig_zag() {
+    assert_eq!(0, IntCompressionUtils::zig_zag_encode(0));
+    assert_eq!(1, IntCompressionUtils::zig_zag_encode(-1));
+    assert_eq!(2, IntCompressionUtils::zig_zag_encode(1));
+    assert_eq!(3, IntCompressionUtils::zig_zag_encode(-2));
+    assert_eq!(4, IntCompressionUtils::zig_zag_encode(2));
+    assert_eq!(379, IntCompressionUtils::zig_zag_encode(-190));
+    assert_eq!(80, IntCompressionUtils::zig_zag_encode(40));
+    assert_eq!(254, IntCompressionUtils::zig_zag_encode(127));
+    assert_eq!(256, IntCompressionUtils::zig_zag_encode(128));
+
+    assert_eq!(0, IntCompressionUtils::zig_zag_decode(0));
+    assert_eq!(-1, IntCompressionUtils::zig_zag_decode(1));
+    assert_eq!(1, IntCompressionUtils::zig_zag_decode(2));
+    assert_eq!(-2, IntCompressionUtils::zig_zag_decode(3));
+    assert_eq!(2, IntCompressionUtils::zig_zag_decode(4));
+    assert_eq!(-5, IntCompressionUtils::zig_zag_decode(9));
+    assert_eq!(-18, IntCompressionUtils::zig_zag_decode(35));
+
+    assert_eq!(
+        64,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(64))
+    );
+
+    assert_eq!(
+        0,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(0))
+    );
+
+    assert_eq!(
+        -17,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(-17))
+    );
+
+    assert_eq!(
+        -12,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(-12))
+    );
+
+    assert_eq!(
+        130,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(130))
+    );
+
+    assert_eq!(
+        (i32::MAX) as i64,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode((i32::MAX) as i64))
+    );
+
+    assert_eq!(
+        i32::MAX as i64 + 3,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(
+            (i32::MAX as i64) + 3
+        ))
+    );
+
+    assert_eq!(
+        i64::MAX,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(i64::MAX))
+    );
+
+    assert_eq!(
+        i64::MIN,
+        IntCompressionUtils::zig_zag_decode(IntCompressionUtils::zig_zag_encode(i64::MIN))
+    );
+}

--- a/tachyon_core/src/storage/compression/int/v1.rs
+++ b/tachyon_core/src/storage/compression/int/v1.rs
@@ -1,0 +1,281 @@
+use crate::storage::FileReaderUtils;
+
+use super::*;
+
+/*
+    Compression Scheme V1:
+--------------------------------------------------------
+    Encoded Header
+    ---------------------
+    | XX | XX | XX | XX |  ... [ NUMBER 1 ] ... [ NUMBER 2 ] ... [ NUMBER 3 ] ... [ NUMBER 4 ]
+    ---------------------
+
+    XX
+    - 00 -> Number is 1 byte (0 to 255)
+    - 01 -> Number is 2 bytes ( signed: -32,768 to 32,767 )
+    - 10 -> Number is 4 bytes
+    - 11 -> Number is 8 bytes
+
+    Based on Google compression algorithm: https://static.googleusercontent.com/media/research.google.com/en//people/jeff/WSDM09-keynote.pdf
+*/
+
+/*
+Examples of Double Delta + Zig Zag
+
+Example 1
+1 5 6 9 12 13 19 23 24 29 32
+
+1st deltas
+4 1 3 3 1 6 4 1 5 3
+
+2nd deltas
+-3 2 0 -2 5 -3 -3 4 -2
+
+Zig Zag:
+5 4 0 3 10 5 5 8 3
+
+----------------------
+Example 2
+1 3 5 7 10 13 15 16 18 20 24
+
+1st
+2 2 2 3 3 2 1 2 2 4
+
+2nd
+0 0 1 0 -1 -1 1 0 2
+
+Zig Zag:
+0 0 2 0 1 1 2 0 4
+
+*/
+pub struct V1;
+pub type PhysicalType = u64;
+
+const EXPONENTS: [usize; 4] = [1, 2, 4, 8];
+
+const VAR_U64_READERS: [fn(&[u8]) -> u64; 4] = [
+    FileReaderUtils::read_u64_1,
+    FileReaderUtils::read_u64_2,
+    FileReaderUtils::read_u64_4,
+    FileReaderUtils::read_u64_8,
+];
+
+pub struct CompressionEngineV1<T: Write> {
+    writer: T,
+    last_timestamp: Timestamp,
+    last_value: PhysicalType,
+    last_deltas: (i64, i64),
+    entries_written: u32,
+
+    buffer: [u64; 4],
+    buffer_idx: usize,
+
+    result: Vec<u8>,
+}
+
+impl<T: Write> CompressionEngine<T> for CompressionEngineV1<T> {
+    type PhysicalType = PhysicalType;
+    fn new(writer: T, header: &Header) -> Self {
+        Self {
+            writer,
+            last_timestamp: header.min_timestamp,
+            last_value: header.first_value.get_uinteger64(),
+            last_deltas: (0, 0),
+            entries_written: 0,
+
+            buffer: [0; 4],
+            buffer_idx: 0,
+
+            result: Vec::new(),
+        }
+    }
+
+    fn consume(&mut self, timestamp: Timestamp, value: PhysicalType) {
+        let curr_deltas = (
+            (timestamp - self.last_timestamp) as i64,
+            (value - self.last_value) as i64,
+        );
+
+        let double_delta_1 = curr_deltas.0 - self.last_deltas.0;
+        let double_delta_2 = curr_deltas.1 - self.last_deltas.1;
+        self.buffer[self.buffer_idx] = IntCompressionUtils::zig_zag_encode(double_delta_1);
+        self.buffer[self.buffer_idx + 1] = IntCompressionUtils::zig_zag_encode(double_delta_2);
+
+        self.buffer_idx += 2;
+        if self.buffer_idx >= self.buffer.len() {
+            self.flush();
+        }
+
+        self.entries_written += 1;
+        self.last_timestamp = timestamp;
+        self.last_value = value;
+        self.last_deltas = curr_deltas;
+    }
+
+    fn flush_all(&mut self) -> usize {
+        self.flush();
+        self.writer.write_all(&self.result).unwrap();
+        self.result.len()
+    }
+}
+
+impl<T: Write> CompressionEngineV1<T> {
+    // Called when the local buffer can be written along with length byte
+    fn flush(&mut self) {
+        if self.buffer_idx == 0 {
+            return;
+        }
+
+        let mut length = 0u8;
+        let mut bytes_needed: u8;
+
+        for j in 0..self.buffer_idx {
+            bytes_needed = Self::bytes_needed_u64(self.buffer[j]);
+            length |= Self::length_encoding(bytes_needed) << (6 - 2 * j);
+        }
+        self.result.push(length);
+
+        for i in 0..self.buffer_idx {
+            self.encode_value(self.buffer[i]);
+        }
+
+        self.buffer_idx = 0;
+    }
+
+    fn length_encoding(n: u8) -> u8 {
+        if n == 1 {
+            0
+        } else if n == 2 {
+            1
+        } else if n <= 4 {
+            2
+        } else if n <= 8 {
+            3
+        } else {
+            panic!("Integer greater than 8 bytes: {}!", n);
+        }
+    }
+
+    fn encode_value(&mut self, n: u64) {
+        const EXPONENTS: [u8; 4] = [1, 2, 4, 8];
+        let n_bytes = Self::bytes_needed_u64(n);
+        let n_bytes = EXPONENTS[Self::length_encoding(n_bytes) as usize];
+        let bytes = n.to_le_bytes();
+        self.result.extend_from_slice(&bytes[0..n_bytes as usize]);
+    }
+
+    fn bytes_needed_u64(n: u64) -> u8 {
+        if n == 0 {
+            return 1;
+        }
+        let mut bytes = 0;
+        let mut temp = n;
+        while temp > 0 {
+            bytes += 1;
+            temp >>= 8; // Shift right by 8 bits (1 byte)
+        }
+        bytes
+    }
+}
+
+pub struct DecompressionEngineV1<T: Read> {
+    reader: T,
+
+    values_read: u32,
+    cur_length_byte: u8,
+
+    current_timestamp: Timestamp,
+    current_value: PhysicalType,
+    last_deltas: (i64, i64),
+
+    next_timestamp: Timestamp,
+    next_value: PhysicalType,
+}
+
+impl<T: Read> DecompressionEngine<T> for DecompressionEngineV1<T> {
+    type PhysicalType = u64;
+
+    fn new(mut reader: T, header: &Header) -> Self {
+        let mut l_buf = [0u8; 1];
+        if header.count > 1 {
+            reader.read_exact(&mut l_buf).unwrap();
+        }
+
+        Self {
+            reader,
+
+            values_read: 1,
+            cur_length_byte: l_buf[0],
+
+            current_timestamp: header.min_timestamp,
+            current_value: header.first_value.get_uinteger64(),
+            last_deltas: (0, 0),
+
+            next_timestamp: 0,
+            next_value: 0,
+        }
+    }
+
+    fn next(&mut self) -> (Timestamp, PhysicalType) {
+        if self.values_read % 2 == 0 {
+            self.current_timestamp = self.next_timestamp;
+            self.current_value = self.next_value;
+            self.values_read += 1;
+            return (self.current_timestamp, self.current_value);
+        }
+
+        // Compute integer lengths
+        let indexes: [usize; 4] = [
+            ((self.cur_length_byte >> 6) & 0b11) as usize,
+            ((self.cur_length_byte >> 4) & 0b11) as usize,
+            ((self.cur_length_byte >> 2) & 0b11) as usize,
+            ((self.cur_length_byte) & 0b11) as usize,
+        ];
+
+        let total_varint_lengths = EXPONENTS[indexes[0]]
+            + EXPONENTS[indexes[1]]
+            + EXPONENTS[indexes[2]]
+            + EXPONENTS[indexes[3]];
+
+        // Read deltas + next length byte
+        let mut buffer = [0u8; 2 * (size_of::<Timestamp>() + size_of::<PhysicalType>()) + 1];
+        self.reader
+            .read_exact(&mut buffer[0..total_varint_lengths + 1])
+            .unwrap();
+
+        let mut decoded_deltas = [0i64; 4];
+        let mut buf_offset = 0;
+
+        for i in 0..4 {
+            let encoded = VAR_U64_READERS[indexes[i]](
+                &buffer[buf_offset..buf_offset + EXPONENTS[indexes[i]]],
+            );
+            buf_offset += EXPONENTS[indexes[i]];
+            decoded_deltas[i] = IntCompressionUtils::zig_zag_decode(encoded);
+        }
+
+        // Compute timestamp / value
+        self.last_deltas.0 += decoded_deltas[0];
+        self.current_timestamp = self
+            .current_timestamp
+            .wrapping_add_signed(self.last_deltas.0);
+
+        self.last_deltas.1 += decoded_deltas[1];
+        self.current_value = self.current_value.wrapping_add_signed(self.last_deltas.1);
+
+        // Compute next timestamp / value
+        self.last_deltas.0 += decoded_deltas[2];
+        self.next_timestamp = self
+            .current_timestamp
+            .wrapping_add_signed(self.last_deltas.0);
+
+        self.last_deltas.1 += decoded_deltas[3];
+        self.next_value = self.current_value.wrapping_add_signed(self.last_deltas.1);
+
+        // Update state
+        self.values_read += 1;
+        self.cur_length_byte = buffer[total_varint_lengths];
+
+        (self.current_timestamp, self.current_value)
+    }
+}

--- a/tachyon_core/src/storage/compression/int/v2.rs
+++ b/tachyon_core/src/storage/compression/int/v2.rs
@@ -1,336 +1,16 @@
-use super::file::Header;
-use super::FileReaderUtils;
-use crate::utils::static_assert;
-use crate::Timestamp;
 use std::io::{Read, Write};
-use std::mem::size_of;
 
-pub type PhysicalType = u64;
-
-const EXPONENTS: [usize; 4] = [1, 2, 4, 8];
-
-const VAR_U64_READERS: [fn(&[u8]) -> u64; 4] = [
-    FileReaderUtils::read_u64_1,
-    FileReaderUtils::read_u64_2,
-    FileReaderUtils::read_u64_4,
-    FileReaderUtils::read_u64_8,
-];
-
-pub struct CompressionUtils;
-
-impl CompressionUtils {
-    #[inline]
-    pub fn zig_zag_decode(n: u64) -> i64 {
-        ((n >> 1) as i64) ^ -((n & 1) as i64)
-    }
-
-    #[inline]
-    pub fn zig_zag_encode(n: i64) -> u64 {
-        ((n >> (i64::BITS as usize - 1)) ^ (n << 1)) as u64
-    }
-}
-
-pub trait CompressionEngine<T: Write> {
-    fn new(writer: T, header: &Header) -> Self
-    where
-        Self: Sized;
-    fn consume(&mut self, timestamp: Timestamp, value: PhysicalType);
-    fn bytes_compressed(&self) -> usize;
-    fn flush_all(&mut self);
-}
-
-pub trait DecompressionEngine<T: Read> {
-    fn new(reader: T, header: &Header) -> Self
-    where
-        Self: Sized;
-    fn next(&mut self) -> (Timestamp, PhysicalType);
-}
-
-pub trait CompressionScheme<R: Read, W: Write> {
-    type Decompressor: DecompressionEngine<R>;
-    type Compressor: CompressionEngine<W>;
-}
-
-#[allow(deprecated)]
-pub mod v1 {
-    use super::*;
-
-    /*
-        Compression Scheme V1:
-    --------------------------------------------------------
-        Encoded Header
-        ---------------------
-        | XX | XX | XX | XX |  ... [ NUMBER 1 ] ... [ NUMBER 2 ] ... [ NUMBER 3 ] ... [ NUMBER 4 ]
-        ---------------------
-
-        XX
-        - 00 -> Number is 1 byte (0 to 255)
-        - 01 -> Number is 2 bytes ( signed: -32,768 to 32,767 )
-        - 10 -> Number is 4 bytes
-        - 11 -> Number is 8 bytes
-
-        Based on Google compression algorithm: https://static.googleusercontent.com/media/research.google.com/en//people/jeff/WSDM09-keynote.pdf
-    */
-
-    /*
-    Examples of Double Delta + Zig Zag
-
-    Example 1
-    1 5 6 9 12 13 19 23 24 29 32
-
-    1st deltas
-    4 1 3 3 1 6 4 1 5 3
-
-    2nd deltas
-    -3 2 0 -2 5 -3 -3 4 -2
-
-    Zig Zag:
-    5 4 0 3 10 5 5 8 3
-
-    ----------------------
-    Example 2
-    1 3 5 7 10 13 15 16 18 20 24
-
-    1st
-    2 2 2 3 3 2 1 2 2 4
-
-    2nd
-    0 0 1 0 -1 -1 1 0 2
-
-    Zig Zag:
-    0 0 2 0 1 1 2 0 4
-
-    */
-    #[deprecated]
-    pub struct V1;
-
-    impl<R: Read, W: Write> CompressionScheme<R, W> for V1 {
-        type Decompressor = DecompressionEngineV1<R>;
-        type Compressor = CompressionEngineV1<W>;
-    }
-
-    #[deprecated]
-    pub struct CompressionEngineV1<T: Write> {
-        writer: T,
-        last_timestamp: Timestamp,
-        last_value: PhysicalType,
-        last_deltas: (i64, i64),
-        entries_written: u32,
-
-        buffer: [u64; 4],
-        buffer_idx: usize,
-
-        result: Vec<u8>,
-    }
-
-    impl<T: Write> CompressionEngine<T> for CompressionEngineV1<T> {
-        fn new(writer: T, header: &Header) -> Self {
-            Self {
-                writer,
-                last_timestamp: header.min_timestamp,
-                last_value: header.first_value.get_uinteger64(),
-                last_deltas: (0, 0),
-                entries_written: 0,
-
-                buffer: [0; 4],
-                buffer_idx: 0,
-
-                result: Vec::new(),
-            }
-        }
-
-        fn consume(&mut self, timestamp: Timestamp, value: PhysicalType) {
-            let curr_deltas = (
-                (timestamp - self.last_timestamp) as i64,
-                (value - self.last_value) as i64,
-            );
-
-            let double_delta_1 = curr_deltas.0 - self.last_deltas.0;
-            let double_delta_2 = curr_deltas.1 - self.last_deltas.1;
-            self.buffer[self.buffer_idx] = CompressionUtils::zig_zag_encode(double_delta_1);
-            self.buffer[self.buffer_idx + 1] = CompressionUtils::zig_zag_encode(double_delta_2);
-
-            self.buffer_idx += 2;
-            if self.buffer_idx >= self.buffer.len() {
-                self.flush();
-            }
-
-            self.entries_written += 1;
-            self.last_timestamp = timestamp;
-            self.last_value = value;
-            self.last_deltas = curr_deltas;
-        }
-
-        fn bytes_compressed(&self) -> usize {
-            self.result.len()
-        }
-
-        fn flush_all(&mut self) {
-            self.flush();
-            self.writer.write_all(&self.result).unwrap();
-        }
-    }
-
-    impl<T: Write> CompressionEngineV1<T> {
-        // Called when the local buffer can be written along with length byte
-        fn flush(&mut self) {
-            if self.buffer_idx == 0 {
-                return;
-            }
-
-            let mut length = 0u8;
-            let mut bytes_needed: u8;
-
-            for j in 0..self.buffer_idx {
-                bytes_needed = Self::bytes_needed_u64(self.buffer[j]);
-                length |= Self::length_encoding(bytes_needed) << (6 - 2 * j);
-            }
-            self.result.push(length);
-
-            for i in 0..self.buffer_idx {
-                self.encode_value(self.buffer[i]);
-            }
-
-            self.buffer_idx = 0;
-        }
-
-        fn length_encoding(n: u8) -> u8 {
-            if n == 1 {
-                0
-            } else if n == 2 {
-                return 1;
-            } else if n <= 4 {
-                return 2;
-            } else if n <= 8 {
-                return 3;
-            } else {
-                panic!("Integer greater than 8 bytes: {}!", n);
-            }
-        }
-
-        fn encode_value(&mut self, n: u64) {
-            const EXPONENTS: [u8; 4] = [1, 2, 4, 8];
-            let n_bytes = Self::bytes_needed_u64(n);
-            let n_bytes = EXPONENTS[Self::length_encoding(n_bytes) as usize];
-            let bytes = n.to_le_bytes();
-            self.result.extend_from_slice(&bytes[0..n_bytes as usize]);
-        }
-
-        fn bytes_needed_u64(n: u64) -> u8 {
-            if n == 0 {
-                return 1;
-            }
-            let mut bytes = 0;
-            let mut temp = n;
-            while temp > 0 {
-                bytes += 1;
-                temp >>= 8; // Shift right by 8 bits (1 byte)
-            }
-            bytes
-        }
-    }
-
-    #[deprecated]
-    pub struct DecompressionEngineV1<T: Read> {
-        reader: T,
-
-        values_read: u32,
-        cur_length_byte: u8,
-
-        current_timestamp: Timestamp,
-        current_value: PhysicalType,
-        last_deltas: (i64, i64),
-
-        next_timestamp: Timestamp,
-        next_value: PhysicalType,
-    }
-
-    impl<T: Read> DecompressionEngine<T> for DecompressionEngineV1<T> {
-        fn new(mut reader: T, header: &Header) -> Self {
-            let mut l_buf = [0u8; 1];
-            if header.count > 1 {
-                reader.read_exact(&mut l_buf).unwrap();
-            }
-
-            Self {
-                reader,
-
-                values_read: 1,
-                cur_length_byte: l_buf[0],
-
-                current_timestamp: header.min_timestamp,
-                current_value: header.first_value.get_uinteger64(),
-                last_deltas: (0, 0),
-
-                next_timestamp: 0,
-                next_value: 0,
-            }
-        }
-
-        fn next(&mut self) -> (Timestamp, PhysicalType) {
-            if self.values_read % 2 == 0 {
-                self.current_timestamp = self.next_timestamp;
-                self.current_value = self.next_value;
-                self.values_read += 1;
-                return (self.current_timestamp, self.current_value);
-            }
-
-            // Compute integer lengths
-            let indexes: [usize; 4] = [
-                ((self.cur_length_byte >> 6) & 0b11) as usize,
-                ((self.cur_length_byte >> 4) & 0b11) as usize,
-                ((self.cur_length_byte >> 2) & 0b11) as usize,
-                ((self.cur_length_byte) & 0b11) as usize,
-            ];
-
-            let total_varint_lengths = EXPONENTS[indexes[0]]
-                + EXPONENTS[indexes[1]]
-                + EXPONENTS[indexes[2]]
-                + EXPONENTS[indexes[3]];
-
-            // Read deltas + next length byte
-            let mut buffer = [0u8; 2 * (size_of::<Timestamp>() + size_of::<PhysicalType>()) + 1];
-            self.reader
-                .read_exact(&mut buffer[0..total_varint_lengths + 1])
-                .unwrap();
-
-            let mut decoded_deltas = [0i64; 4];
-            let mut buf_offset = 0;
-
-            for i in 0..4 {
-                let encoded = VAR_U64_READERS[indexes[i]](
-                    &buffer[buf_offset..buf_offset + EXPONENTS[indexes[i]]],
-                );
-                buf_offset += EXPONENTS[indexes[i]];
-                decoded_deltas[i] = CompressionUtils::zig_zag_decode(encoded);
-            }
-
-            // Compute timestamp / value
-            self.last_deltas.0 += decoded_deltas[0];
-            self.current_timestamp = self
-                .current_timestamp
-                .wrapping_add_signed(self.last_deltas.0);
-
-            self.last_deltas.1 += decoded_deltas[1];
-            self.current_value = self.current_value.wrapping_add_signed(self.last_deltas.1);
-
-            // Compute next timestamp / value
-            self.last_deltas.0 += decoded_deltas[2];
-            self.next_timestamp = self
-                .current_timestamp
-                .wrapping_add_signed(self.last_deltas.0);
-
-            self.last_deltas.1 += decoded_deltas[3];
-            self.next_value = self.current_value.wrapping_add_signed(self.last_deltas.1);
-
-            // Update state
-            self.values_read += 1;
-            self.cur_length_byte = buffer[total_varint_lengths];
-
-            (self.current_timestamp, self.current_value)
-        }
-    }
-}
+use crate::{
+    storage::{
+        compression::{CompressionEngine, DecompressionEngine},
+        FileReaderUtils,
+    },
+    tachyon_benchmarks::Header,
+    utils::static_assert,
+    Timestamp,
+};
+
+use super::IntCompressionUtils;
 
 /*
     Compression Scheme V2:
@@ -365,11 +45,7 @@ pub mod v1 {
     or encoded in little-endian format otherwise.
 */
 pub struct V2;
-
-impl<R: Read, W: Write> CompressionScheme<R, W> for V2 {
-    type Decompressor = DecompressionEngineV2<R>;
-    type Compressor = CompressionEngineV2<W>;
-}
+pub type PhysicalType = u64;
 
 const V2_CHUNK_SIZE: usize = 16;
 static_assert!(V2_CHUNK_SIZE % 8 == 0);
@@ -410,6 +86,8 @@ pub struct CompressionEngineV2<T: Write> {
 }
 
 impl<T: Write> CompressionEngine<T> for CompressionEngineV2<T> {
+    type PhysicalType = u64;
+
     fn new(writer: T, header: &Header) -> Self {
         Self {
             writer,
@@ -437,10 +115,10 @@ impl<T: Write> CompressionEngine<T> for CompressionEngineV2<T> {
         );
 
         let double_delta = curr_deltas.0 - (self.last_deltas.0);
-        self.ts_d_deltas[self.buffer_idx] = CompressionUtils::zig_zag_encode(double_delta);
+        self.ts_d_deltas[self.buffer_idx] = IntCompressionUtils::zig_zag_encode(double_delta);
 
         let double_delta = curr_deltas.1 - (self.last_deltas.1);
-        self.v_d_deltas[self.buffer_idx] = CompressionUtils::zig_zag_encode(double_delta);
+        self.v_d_deltas[self.buffer_idx] = IntCompressionUtils::zig_zag_encode(double_delta);
 
         self.buffer_idx += 1;
         if self.buffer_idx >= V2_CHUNK_SIZE {
@@ -453,14 +131,11 @@ impl<T: Write> CompressionEngine<T> for CompressionEngineV2<T> {
         self.last_deltas = curr_deltas;
     }
 
-    fn bytes_compressed(&self) -> usize {
-        self.result.len()
-    }
-
-    fn flush_all(&mut self) {
+    fn flush_all(&mut self) -> usize {
         self.flush();
         self.flush_chunk();
         self.writer.write_all(&self.result).unwrap();
+        self.result.len()
     }
 }
 
@@ -556,6 +231,8 @@ pub struct DecompressionEngineV2<T: Read> {
 }
 
 impl<T: Read> DecompressionEngine<T> for DecompressionEngineV2<T> {
+    type PhysicalType = PhysicalType;
+
     fn new(reader: T, header: &Header) -> Self {
         Self {
             reader,
@@ -601,7 +278,7 @@ impl<T: Read> DecompressionEngine<T> for DecompressionEngineV2<T> {
                         let shift = 8 - num_bits as usize - bit_idx;
 
                         let encoded = ((buf[byte_idx] >> shift) & ((1 << num_bits) - 1)) as u64;
-                        *x = CompressionUtils::zig_zag_decode(encoded);
+                        *x = IntCompressionUtils::zig_zag_decode(encoded);
                     }
                 } else {
                     for (i, x) in arr.iter_mut().enumerate().take(V2_CHUNK_SIZE) {
@@ -609,7 +286,7 @@ impl<T: Read> DecompressionEngine<T> for DecompressionEngineV2<T> {
                         let val = V2_INT_READERS[length_code as usize - 3](
                             &buf[byte_idx..byte_idx + num_bits as usize / 8],
                         );
-                        *x = CompressionUtils::zig_zag_decode(val);
+                        *x = IntCompressionUtils::zig_zag_decode(val);
                     }
                 }
                 self.chunk_idx += 1;
@@ -634,13 +311,11 @@ impl<T: Read> DecompressionEngine<T> for DecompressionEngineV2<T> {
     }
 }
 
-pub type DefaultScheme = V2;
-
 #[cfg(test)]
 mod tests {
     use super::{
-        CompressionEngine, CompressionEngineV2, CompressionUtils, DecompressionEngine,
-        DecompressionEngineV2, V2_CHUNK_SIZE,
+        CompressionEngine, CompressionEngineV2, DecompressionEngine, DecompressionEngineV2,
+        V2_CHUNK_SIZE,
     };
     use crate::storage::file::Header;
     use crate::{StreamId, ValueType, Version};
@@ -791,73 +466,5 @@ mod tests {
             assert_eq!(t, timestamps[i]);
             assert_eq!(v, values[i]);
         }
-    }
-
-    #[test]
-    fn test_zig_zag() {
-        assert_eq!(0, CompressionUtils::zig_zag_encode(0));
-        assert_eq!(1, CompressionUtils::zig_zag_encode(-1));
-        assert_eq!(2, CompressionUtils::zig_zag_encode(1));
-        assert_eq!(3, CompressionUtils::zig_zag_encode(-2));
-        assert_eq!(4, CompressionUtils::zig_zag_encode(2));
-        assert_eq!(379, CompressionUtils::zig_zag_encode(-190));
-        assert_eq!(80, CompressionUtils::zig_zag_encode(40));
-        assert_eq!(254, CompressionUtils::zig_zag_encode(127));
-        assert_eq!(256, CompressionUtils::zig_zag_encode(128));
-
-        assert_eq!(0, CompressionUtils::zig_zag_decode(0));
-        assert_eq!(-1, CompressionUtils::zig_zag_decode(1));
-        assert_eq!(1, CompressionUtils::zig_zag_decode(2));
-        assert_eq!(-2, CompressionUtils::zig_zag_decode(3));
-        assert_eq!(2, CompressionUtils::zig_zag_decode(4));
-        assert_eq!(-5, CompressionUtils::zig_zag_decode(9));
-        assert_eq!(-18, CompressionUtils::zig_zag_decode(35));
-
-        assert_eq!(
-            64,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(64))
-        );
-
-        assert_eq!(
-            0,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(0))
-        );
-
-        assert_eq!(
-            -17,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(-17))
-        );
-
-        assert_eq!(
-            -12,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(-12))
-        );
-
-        assert_eq!(
-            130,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(130))
-        );
-
-        assert_eq!(
-            (i32::MAX) as i64,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode((i32::MAX) as i64))
-        );
-
-        assert_eq!(
-            i32::MAX as i64 + 3,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(
-                (i32::MAX as i64) + 3
-            ))
-        );
-
-        assert_eq!(
-            i64::MAX,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(i64::MAX))
-        );
-
-        assert_eq!(
-            i64::MIN,
-            CompressionUtils::zig_zag_decode(CompressionUtils::zig_zag_encode(i64::MIN))
-        );
     }
 }

--- a/tachyon_core/src/storage/compression/mod.rs
+++ b/tachyon_core/src/storage/compression/mod.rs
@@ -1,0 +1,24 @@
+use std::io::{Read, Write};
+
+use crate::Timestamp;
+
+use super::file::Header;
+
+pub mod int;
+
+pub trait CompressionEngine<W: Write> {
+    type PhysicalType;
+    fn new(writer: W, header: &Header) -> Self
+    where
+        Self: Sized;
+    fn consume(&mut self, timestamp: Timestamp, value: Self::PhysicalType);
+    fn flush_all(&mut self) -> usize;
+}
+
+pub trait DecompressionEngine<R: Read> {
+    type PhysicalType;
+    fn new(reader: R, header: &Header) -> Self
+    where
+        Self: Sized;
+    fn next(&mut self) -> (Timestamp, Self::PhysicalType);
+}


### PR DESCRIPTION
- Preparing the compression module to add float compression techniques
- Pretty much just moved around some files / introduced the ability to dynamically select which compression to use
- (We will eventually store which compression is used in each file, so we can decompress every file even if we upgrade our DB)


Open to suggestions for improvements, but here is what I did:
- Introduce enum for IntCompression, with V1, and V2 as variants
- Move each compression method to its own file under `compression/int` as part of a refactor

In the following PRs, will introduce `compression/float` and implement float compression