### PR TITLE
Export CSV as f64 values

### DIFF
--- a/tachyon_cli/src/main.rs
+++ b/tachyon_cli/src/main.rs
@@ -185,7 +185,8 @@ fn handle_query_command(
 
             let f32_timeseries: Vec<(f32, f32)> = timeseries
                 .iter()
-                .map(|(timestamp, value)| (*timestamp as f32, *value as f32)).collect();
+                .map(|(timestamp, value)| (*timestamp as f32, *value as f32))
+                .collect();
 
             Chart::new(
                 180,
@@ -195,7 +196,6 @@ fn handle_query_command(
             )
             .lineplot(&Shape::Lines(&f32_timeseries))
             .display();
-
         }
     }
 }


### PR DESCRIPTION
Closes [Tac-9](https://merms.atlassian.net/browse/TAC-9)

Currently untested.

When exporting the CSV results of a query, we were rounding to f32. This is because the graphing software requires data to be f32. So I had to create two different lists of the results - one where the data is f32, the other where the data is f64 as normal. So this will negatively impact performance for sure.