### PR TITLE
Aggregation by subperiod

### DIFF
--- a/tachyon_core/src/execution/node/aggregate.rs
+++ b/tachyon_core/src/execution/node/aggregate.rs
@@ -67,7 +67,7 @@ impl AggregateNode {
         )
     }
 
-    fn child_next_vector(
+    fn next_child_vector(
         child: &mut AggregateChild,
         subperiod: Option<Duration>,
         conn: &mut Connection,
@@ -80,6 +80,7 @@ impl AggregateNode {
         };
 
         if let Some(vector) = next_vector {
+            // Return None if next vector is past subperiod; next call will return it
             if vector.timestamp > child.end_timestamp {
                 child.peeked_vector = Some(vector);
                 if let Some(subperiod) = subperiod {
@@ -100,19 +101,11 @@ impl AggregateNode {
         subperiod: Option<Duration>,
         conn: &mut Connection,
     ) -> Option<Value> {
-        if child.done {
-            return None;
-        }
         let value_type = child.node.value_type();
-
-        let mut sum = if subperiod.is_some() {
-            Value::get_default(value_type)
-        } else {
-            child.node.next_vector(conn)?.value
-        };
+        let mut sum = AggregateNode::next_child_vector(child, subperiod, conn)?.value;
 
         while let Some(Vector { value, .. }) =
-            AggregateNode::child_next_vector(child, subperiod, conn)
+            AggregateNode::next_child_vector(child, subperiod, conn)
         {
             sum = sum.add_same(value_type, &value);
         }
@@ -124,22 +117,20 @@ impl AggregateNode {
         subperiod: Option<Duration>,
         conn: &mut Connection,
     ) -> Option<Value> {
-        if child.done {
-            return None;
-        }
         let value_type = child.node.value_type();
+        let first_vector = AggregateNode::next_child_vector(child, subperiod, conn)?;
 
         if AggregateNode::using_scanhint(child, subperiod) {
-            let mut count = Value::get_default(value_type);
+            let mut count = first_vector.value;
             while let Some(Vector { value, .. }) =
-                AggregateNode::child_next_vector(child, subperiod, conn)
+                AggregateNode::next_child_vector(child, subperiod, conn)
             {
                 count = count.add_same(value_type, &value);
             }
             Some(count)
         } else {
-            let mut count = 0u64;
-            while AggregateNode::child_next_vector(child, subperiod, conn).is_some() {
+            let mut count = 1u64;
+            while AggregateNode::next_child_vector(child, subperiod, conn).is_some() {
                 count += 1;
             }
             Some(count.into())
@@ -165,7 +156,11 @@ impl ExecutorNode for AggregateNode {
     }
 
     fn return_type(&self) -> ReturnType {
-        ReturnType::Scalar
+        if self.subperiod.is_some() {
+            ReturnType::Vector
+        } else {
+            ReturnType::Scalar
+        }
     }
 
     fn next_scalar(&mut self, conn: &mut Connection) -> Option<Value> {
@@ -178,7 +173,7 @@ impl ExecutorNode for AggregateNode {
                 let sum_value_type = self.child.node.value_type();
                 let sum_opt = AggregateNode::next_sum(&mut self.child, self.subperiod, conn);
 
-                // SAFETY: we always create other_child when AggregateType is Average
+                // SAFETY: we create other_child when AggregateType is Average
                 let count_value_type = if AggregateNode::using_scanhint(
                     self.other_child.as_ref().unwrap(),
                     self.subperiod,
@@ -203,10 +198,10 @@ impl ExecutorNode for AggregateNode {
             AggregateType::Min | AggregateType::Max => {
                 let value_type = self.value_type();
                 let mut val =
-                    AggregateNode::child_next_vector(&mut self.child, self.subperiod, conn)?.value;
+                    AggregateNode::next_child_vector(&mut self.child, self.subperiod, conn)?.value;
 
                 while let Some(Vector { value, .. }) =
-                    AggregateNode::child_next_vector(&mut self.child, self.subperiod, conn)
+                    AggregateNode::next_child_vector(&mut self.child, self.subperiod, conn)
                 {
                     if self.aggregate_type == AggregateType::Min {
                         val = val.min_same(value_type, &value);
@@ -218,5 +213,17 @@ impl ExecutorNode for AggregateNode {
                 Some(val)
             }
         }
+    }
+
+    fn next_vector(&mut self, conn: &mut Connection) -> Option<Vector> {
+        while !self.child.done {
+            if let Some(value) = self.next_scalar(conn) {
+                return Some(Vector {
+                    timestamp: self.child.end_timestamp,
+                    value,
+                });
+            }
+        }
+        None
     }
 }

--- a/tachyon_core/src/execution/node/aggregate.rs
+++ b/tachyon_core/src/execution/node/aggregate.rs
@@ -15,8 +15,10 @@ pub enum AggregateType {
 
 struct AggregateChild {
     node: Box<TNode>,
-    peeked_vector: Option<Vector>, // Next vector is stored here if looked at but not returned
-    end: Timestamp,                // End timestamp of aggregation (sub)period
+    /// Next vector is stored here if looked at but not returned
+    peeked_vector: Option<Vector>,
+    /// End timestamp of aggregation (sub)period
+    end: Timestamp,
     done: bool,
 }
 

--- a/tachyon_core/src/execution/node/aggregate.rs
+++ b/tachyon_core/src/execution/node/aggregate.rs
@@ -235,7 +235,9 @@ impl ExecutorNode for AggregateNode {
     }
 
     fn next_vector(&mut self, conn: &mut Connection) -> Option<Vector> {
+        // While there are still more vectors to be read
         while !self.child.done {
+            // If the current subperiod has an aggregate result, return it
             if let Some(value) = self.next_scalar(conn) {
                 let timestamp = cmp::min(self.child.end, self.end); // Bound by end timestamp
                 return Some(Vector { timestamp, value });

--- a/tachyon_core/src/execution/node/aggregate.rs
+++ b/tachyon_core/src/execution/node/aggregate.rs
@@ -85,6 +85,7 @@ impl AggregateNode {
             // Retrieve peeked vector; else, get next vector
             let next_vector = if let Some(vector) = child.peeked_vector {
                 child.peeked_vector = None;
+                // No need to check if this is past the query end as the planner ensures all child vectors obey start <= t <= end
                 child.end += subperiod.as_millis() as u64;
                 Some(vector)
             } else {
@@ -135,11 +136,13 @@ impl AggregateNode {
         subperiod: Option<Duration>,
         conn: &mut Connection,
     ) -> Option<Value> {
+        if child.done {
+            return None;
+        }
         let value_type = child.node.value_type();
-        let first_vector = AggregateNode::next_child_vector(child, subperiod, conn)?;
 
         if AggregateNode::using_scanhint(child, subperiod) {
-            let mut count = first_vector.value;
+            let mut count = Value::get_default(value_type);
             while let Some(Vector { value, .. }) =
                 AggregateNode::next_child_vector(child, subperiod, conn)
             {
@@ -147,7 +150,7 @@ impl AggregateNode {
             }
             Some(count)
         } else {
-            let mut count = 1u64; // We have already read the first vector
+            let mut count = 0u64;
             while AggregateNode::next_child_vector(child, subperiod, conn).is_some() {
                 count += 1;
             }

--- a/tachyon_core/src/execution/node/aggregate.rs
+++ b/tachyon_core/src/execution/node/aggregate.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{cmp, time::Duration};
 
 use crate::{Connection, ReturnType, Timestamp, Value, ValueType, Vector};
 
@@ -16,13 +16,14 @@ pub enum AggregateType {
 struct AggregateChild {
     node: Box<TNode>,
     peeked_vector: Option<Vector>, // Next vector is stored here if looked at but not returned
-    end_timestamp: Timestamp,      // End timestamp of aggregation (sub)period
+    end: Timestamp,                // End timestamp of aggregation (sub)period
     done: bool,
 }
 
 pub struct AggregateNode {
     pub aggregate_type: AggregateType,
     subperiod: Option<Duration>,
+    end: Timestamp,
     child: AggregateChild,
     other_child: Option<AggregateChild>,
 }
@@ -45,16 +46,17 @@ impl AggregateNode {
         Self {
             aggregate_type,
             subperiod,
+            end,
             child: AggregateChild {
                 node: child,
                 peeked_vector: None,
-                end_timestamp: curr_end,
+                end: curr_end,
                 done: false,
             },
             other_child: other_child.map(|other_child| AggregateChild {
                 node: other_child,
                 peeked_vector: None,
-                end_timestamp: curr_end,
+                end: curr_end,
                 done: false,
             }),
         }
@@ -72,8 +74,12 @@ impl AggregateNode {
         subperiod: Option<Duration>,
         conn: &mut Connection,
     ) -> Option<Vector> {
+        // Retrieve peeked vector; else, get next vector
         let next_vector = if let Some(vector) = child.peeked_vector {
             child.peeked_vector = None;
+            if let Some(subperiod) = subperiod {
+                child.end += subperiod.as_millis() as u64;
+            }
             Some(vector)
         } else {
             child.node.next_vector(conn)
@@ -81,11 +87,8 @@ impl AggregateNode {
 
         if let Some(vector) = next_vector {
             // Return None if next vector is past subperiod; next call will return it
-            if vector.timestamp > child.end_timestamp {
-                child.peeked_vector = Some(vector);
-                if let Some(subperiod) = subperiod {
-                    child.end_timestamp += subperiod.as_millis() as u64;
-                }
+            if vector.timestamp > child.end {
+                child.peeked_vector = Some(vector); // Store peeked vector
                 None
             } else {
                 Some(vector)
@@ -218,10 +221,8 @@ impl ExecutorNode for AggregateNode {
     fn next_vector(&mut self, conn: &mut Connection) -> Option<Vector> {
         while !self.child.done {
             if let Some(value) = self.next_scalar(conn) {
-                return Some(Vector {
-                    timestamp: self.child.end_timestamp,
-                    value,
-                });
+                let timestamp = cmp::min(self.child.end, self.end); // Bound by end timestamp
+                return Some(Vector { timestamp, value });
             }
         }
         None

--- a/tachyon_core/src/execution/node/aggregate.rs
+++ b/tachyon_core/src/execution/node/aggregate.rs
@@ -19,6 +19,7 @@ struct AggregateChild {
     peeked_vector: Option<Vector>,
     /// End timestamp of aggregation (sub)period
     end: Timestamp,
+    /// Set to true when all vectors have been read
     done: bool,
 }
 
@@ -71,30 +72,42 @@ impl AggregateNode {
         )
     }
 
+    /// Wrapper around next_vector().
+    /// When the next vector is past the current subperiod, returns None; the next call will return that vector.
+    /// When there are no more vectors, returns None and sets child.done = true.
     fn next_child_vector(
         child: &mut AggregateChild,
         subperiod: Option<Duration>,
         conn: &mut Connection,
     ) -> Option<Vector> {
-        // Retrieve peeked vector; else, get next vector
-        let next_vector = if let Some(vector) = child.peeked_vector {
-            child.peeked_vector = None;
-            if let Some(subperiod) = subperiod {
+        // Aggregation by subperiod
+        if let Some(subperiod) = subperiod {
+            // Retrieve peeked vector; else, get next vector
+            let next_vector = if let Some(vector) = child.peeked_vector {
+                child.peeked_vector = None;
                 child.end += subperiod.as_millis() as u64;
-            }
-            Some(vector)
-        } else {
-            child.node.next_vector(conn)
-        };
-
-        if let Some(vector) = next_vector {
-            // Return None if next vector is past subperiod; next call will return it
-            if vector.timestamp > child.end {
-                child.peeked_vector = Some(vector); // Store peeked vector
-                None
-            } else {
                 Some(vector)
+            } else {
+                child.node.next_vector(conn)
+            };
+
+            if let Some(vector) = next_vector {
+                // Return None if next vector is past subperiod; next call will return it
+                if vector.timestamp > child.end {
+                    child.peeked_vector = Some(vector);
+                    // child.done = true is not set here as there will be more vectors in the next subperiod
+                    None
+                } else {
+                    Some(vector)
+                }
+            } else {
+                child.done = true;
+                None
             }
+
+            // Regular aggregation
+        } else if let Some(vector) = child.node.next_vector(conn) {
+            Some(vector)
         } else {
             child.done = true;
             None
@@ -134,7 +147,7 @@ impl AggregateNode {
             }
             Some(count)
         } else {
-            let mut count = 1u64;
+            let mut count = 1u64; // We have already read the first vector
             while AggregateNode::next_child_vector(child, subperiod, conn).is_some() {
                 count += 1;
             }
@@ -194,6 +207,7 @@ impl ExecutorNode for AggregateNode {
                 );
 
                 match (sum_opt, count_opt) {
+                    // sum and count will either both be Some or both be None
                     (Some(sum), Some(count)) => {
                         Some(sum.div(sum_value_type, &count, count_value_type))
                     }

--- a/tachyon_core/src/execution/node/mod.rs
+++ b/tachyon_core/src/execution/node/mod.rs
@@ -87,6 +87,7 @@ impl ExecutorNode for TNode {
             TNode::VectorToVector(sel) => sel.next_vector(conn),
             TNode::VectorToScalar(sel) => sel.next_vector(conn),
             TNode::BinaryOp(sel) => sel.next_vector(conn),
+            TNode::Aggregate(sel) => sel.next_vector(conn),
             _ => panic!("next_vector not implemented for this node!"),
         }
     }

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -829,23 +829,22 @@ mod tests {
         let mut conn = Connection::new(root_dir).unwrap();
 
         // Insert dummy values
-        let timestamps = [10, 20, 30, 40];
-        let values = [2i64, 4, 6, 8];
+        let timestamps = [0, 10, 20, 30, 40];
+        let values = [10i64, 2, 4, 6, 8];
         let mut inserter = create_stream_helper(&mut conn, r#"ints"#, ValueType::Integer64);
         for (t, v) in zip(timestamps, values) {
             inserter.insert(t, v.into()).unwrap();
         }
         inserter.flush().unwrap();
 
-        let timestamps = [10, 20, 30, 40];
-        let values = [1u64, 2, 3, 4];
+        let values = [5u64, 1, 2, 3, 4];
         let mut inserter = create_stream_helper(&mut conn, r#"uints"#, ValueType::UInteger64);
         for (t, v) in zip(timestamps, values) {
             inserter.insert(t, v.into()).unwrap();
         }
         inserter.flush().unwrap();
 
-        let values = [4.1, 3.2, 2.3, 1.4];
+        let values = [5.0, 4.1, 3.2, 2.3, 1.4];
         let mut inserter = create_stream_helper(&mut conn, r#"floats"#, ValueType::Float64);
         for (t, v) in zip(timestamps, values) {
             inserter.insert(t, v.into()).unwrap();
@@ -897,7 +896,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints + floats"#,
-            &[6.1, 7.2, 8.3, 9.4].map(|x| x.into()),
+            &[15.0, 6.1, 7.2, 8.3, 9.4].map(|x| x.into()),
             None,
         );
     }
@@ -908,7 +907,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints - uints"#,
-            &[1i64, 2, 3, 4].map(|x| x.into()),
+            &[5i64, 1, 2, 3, 4].map(|x| x.into()),
             None,
         );
     }
@@ -919,7 +918,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints * floats"#,
-            &[8.2, 12.8, 13.8, 11.2].map(|x| x.into()),
+            &[50.0, 8.2, 12.8, 13.8, 11.2].map(|x| x.into()),
             None,
         );
     }
@@ -930,7 +929,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints / uints"#,
-            &[2.0, 2.0, 2.0, 2.0].map(|x| x.into()),
+            &[2.0, 2.0, 2.0, 2.0, 2.0].map(|x| x.into()),
             None,
         );
     }
@@ -941,7 +940,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints % floats"#,
-            &[2.0, 0.8, 1.4, 1.0].map(|x| x.into()),
+            &[0.0, 2.0, 0.8, 1.4, 1.0].map(|x| x.into()),
             None,
         );
     }
@@ -952,7 +951,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints + 2"#,
-            &[4.0, 6.0, 8.0, 10.0].map(|x| x.into()),
+            &[12.0, 4.0, 6.0, 8.0, 10.0].map(|x| x.into()),
             None,
         );
     }
@@ -963,7 +962,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"uints - 2.5"#,
-            &[-1.5, -0.5, 0.5, 1.5].map(|x| x.into()),
+            &[2.5, -1.5, -0.5, 0.5, 1.5].map(|x| x.into()),
             None,
         );
     }
@@ -974,7 +973,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"floats * 11"#,
-            &[45.1, 35.2, 25.3, 15.4].map(|x| x.into()),
+            &[55.0, 45.1, 35.2, 25.3, 15.4].map(|x| x.into()),
             None,
         );
     }
@@ -985,7 +984,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"ints / -4"#,
-            &[-0.5, -1.0, -1.5, -2.0].map(|x| x.into()),
+            &[-2.5, -0.5, -1.0, -1.5, -2.0].map(|x| x.into()),
             None,
         );
     }
@@ -996,7 +995,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"uints % 2"#,
-            &[1.0, 0.0, 1.0, 0.0].map(|x| x.into()),
+            &[1.0, 1.0, 0.0, 1.0, 0.0].map(|x| x.into()),
             None,
         );
     }
@@ -1007,7 +1006,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"(ints % 4) == 2"#,
-            &[2.0, 2.0].map(|x| x.into()),
+            &[2.0, 2.0, 2.0].map(|x| x.into()),
             None,
         );
     }
@@ -1018,7 +1017,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"uints != 2"#,
-            &[1i64, 3, 4].map(|x| x.into()),
+            &[5i64, 1, 3, 4].map(|x| x.into()),
             None,
         );
     }
@@ -1029,7 +1028,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"floats > 2.3"#,
-            &[4.1, 3.2].map(|x| x.into()),
+            &[5.0, 4.1, 3.2].map(|x| x.into()),
             None,
         );
     }
@@ -1051,7 +1050,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"floats >= 2.3"#,
-            &[4.1, 3.2, 2.3].map(|x| x.into()),
+            &[5.0, 4.1, 3.2, 2.3].map(|x| x.into()),
             None,
         );
     }
@@ -1084,7 +1083,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"sum(ints)"#,
-            &[20i64].map(|x| x.into()),
+            &[30i64].map(|x| x.into()),
             None,
         );
     }
@@ -1101,7 +1100,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"sum(ints)[15ms]"#,
-            &[2i64, 10, 8].map(|x| x.into()),
+            &[12i64, 10, 8].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
     }
@@ -1112,7 +1111,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"count(uints)"#,
-            &[4i64].map(|x| x.into()),
+            &[5i64].map(|x| x.into()),
             None,
         );
     }
@@ -1129,7 +1128,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"count(ints)[15ms]"#,
-            &[1i64, 2, 1].map(|x| x.into()),
+            &[2i64, 2, 1].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
     }
@@ -1140,7 +1139,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"avg(floats)"#,
-            &[2.75].map(|x| x.into()),
+            &[3.2].map(|x| x.into()),
             None,
         );
     }
@@ -1157,7 +1156,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"avg(ints)[15ms]"#,
-            &[2.0, 5.0, 8.0].map(|x| x.into()),
+            &[6.0, 5.0, 8.0].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
     }
@@ -1196,7 +1195,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"max(uints)"#,
-            &[4u64].map(|x| x.into()),
+            &[5u64].map(|x| x.into()),
             None,
         );
     }
@@ -1213,7 +1212,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"max(ints)[15ms]"#,
-            &[2i64, 6, 8].map(|x| x.into()),
+            &[10i64, 6, 8].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
     }
@@ -1224,8 +1223,8 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"min(ints)[4ms]"#,
-            &[2i64, 4, 6, 8].map(|x| x.into()),
-            Some(&[12u64, 20, 32, 40]),
+            &[10i64, 2, 4, 6, 8].map(|x| x.into()),
+            Some(&[4u64, 12, 20, 32, 40]),
         );
     }
 
@@ -1235,8 +1234,19 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"sum(count(ints)[4ms])"#,
-            &[4i64].map(|x| x.into()),
+            &[5i64].map(|x| x.into()),
             None,
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_aggregate_over_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"sum(count(ints)[4ms])[16ms]"#,
+            &[2i64, 2, 1].map(|x| x.into()),
+            Some(&[16u64, 32, 40]),
         );
     }
 
@@ -1246,7 +1256,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"topk(2, ints)"#,
-            &[8i64, 6].map(|x| x.into()),
+            &[10i64, 8].map(|x| x.into()),
             None,
         );
     }
@@ -1257,7 +1267,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"topk(100, uints)"#,
-            &[4u64, 3, 2, 1].map(|x| x.into()),
+            &[5u64, 4, 3, 2, 1].map(|x| x.into()),
             None,
         );
     }
@@ -1285,7 +1295,7 @@ mod tests {
         execution_test_helper(
             dirs[0].clone(),
             r#"bottomk(100, uints)"#,
-            &[1u64, 2, 3, 4].map(|x| x.into()),
+            &[1u64, 2, 3, 4, 5].map(|x| x.into()),
             None,
         );
     }

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -595,7 +595,7 @@ pub mod tachyon_benchmarks {
 mod tests {
     use crate::{
         utils::test::set_up_dirs, Connection, Inserter, Query, ReturnType, Timestamp, Value,
-        ValueType,
+        ValueType, Vector,
     };
     use std::{borrow::Borrow, collections::HashSet, iter::zip, path::PathBuf};
 
@@ -820,7 +820,12 @@ mod tests {
         assert_eq!(i, 4);
     }
 
-    fn execution_test_helper(root_dir: PathBuf, query: &str, expected: &[Value]) {
+    fn execution_test_helper(
+        root_dir: PathBuf,
+        query: &str,
+        expected: &[Value],
+        expected_timestamps: Option<&[Timestamp]>,
+    ) {
         let mut conn = Connection::new(root_dir).unwrap();
 
         // Insert dummy values
@@ -847,16 +852,22 @@ mod tests {
         }
         inserter.flush().unwrap();
 
-        let mut stmt = conn.prepare_query(query, Some(0), Some(100)).unwrap();
+        let mut stmt = conn.prepare_query(query, Some(0), Some(40)).unwrap();
 
         // Process results
         let mut i: usize = 0;
         loop {
-            let res = match stmt.return_type() {
-                ReturnType::Vector => stmt.next_vector().map(|next| next.value),
-                ReturnType::Scalar => stmt.next_scalar(),
+            let (value, timestamp) = match stmt.return_type() {
+                ReturnType::Vector => {
+                    if let Some(Vector { value, timestamp }) = stmt.next_vector() {
+                        (Some(value), Some(timestamp))
+                    } else {
+                        (None, None)
+                    }
+                }
+                ReturnType::Scalar => (stmt.next_scalar(), None),
             };
-            match res {
+            match value {
                 Some(res) => match stmt.value_type() {
                     ValueType::Integer64 => {
                         assert!(expected[i].eq_same(stmt.value_type(), &res))
@@ -873,6 +884,9 @@ mod tests {
                     break;
                 }
             }
+            if let Some(expected_timestamps) = expected_timestamps {
+                assert!(timestamp.is_some_and(|x| x == expected_timestamps[i]));
+            }
             i += 1;
         }
     }
@@ -884,6 +898,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints + floats"#,
             &[6.1, 7.2, 8.3, 9.4].map(|x| x.into()),
+            None,
         );
     }
 
@@ -894,6 +909,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints - uints"#,
             &[1i64, 2, 3, 4].map(|x| x.into()),
+            None,
         );
     }
 
@@ -904,6 +920,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints * floats"#,
             &[8.2, 12.8, 13.8, 11.2].map(|x| x.into()),
+            None,
         );
     }
 
@@ -914,6 +931,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints / uints"#,
             &[2.0, 2.0, 2.0, 2.0].map(|x| x.into()),
+            None,
         );
     }
 
@@ -924,6 +942,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints % floats"#,
             &[2.0, 0.8, 1.4, 1.0].map(|x| x.into()),
+            None,
         );
     }
 
@@ -934,6 +953,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints + 2"#,
             &[4.0, 6.0, 8.0, 10.0].map(|x| x.into()),
+            None,
         );
     }
 
@@ -944,6 +964,7 @@ mod tests {
             dirs[0].clone(),
             r#"uints - 2.5"#,
             &[-1.5, -0.5, 0.5, 1.5].map(|x| x.into()),
+            None,
         );
     }
 
@@ -954,6 +975,7 @@ mod tests {
             dirs[0].clone(),
             r#"floats * 11"#,
             &[45.1, 35.2, 25.3, 15.4].map(|x| x.into()),
+            None,
         );
     }
 
@@ -964,6 +986,7 @@ mod tests {
             dirs[0].clone(),
             r#"ints / -4"#,
             &[-0.5, -1.0, -1.5, -2.0].map(|x| x.into()),
+            None,
         );
     }
 
@@ -974,6 +997,7 @@ mod tests {
             dirs[0].clone(),
             r#"uints % 2"#,
             &[1.0, 0.0, 1.0, 0.0].map(|x| x.into()),
+            None,
         );
     }
 
@@ -984,6 +1008,7 @@ mod tests {
             dirs[0].clone(),
             r#"(ints % 4) == 2"#,
             &[2.0, 2.0].map(|x| x.into()),
+            None,
         );
     }
 
@@ -994,6 +1019,7 @@ mod tests {
             dirs[0].clone(),
             r#"uints != 2"#,
             &[1i64, 3, 4].map(|x| x.into()),
+            None,
         );
     }
 
@@ -1004,6 +1030,7 @@ mod tests {
             dirs[0].clone(),
             r#"floats > 2.3"#,
             &[4.1, 3.2].map(|x| x.into()),
+            None,
         );
     }
 
@@ -1014,6 +1041,7 @@ mod tests {
             dirs[0].clone(),
             r#"floats < 3.2"#,
             &[2.3, 1.4].map(|x| x.into()),
+            None,
         );
     }
 
@@ -1024,6 +1052,7 @@ mod tests {
             dirs[0].clone(),
             r#"floats >= 2.3"#,
             &[4.1, 3.2, 2.3].map(|x| x.into()),
+            None,
         );
     }
 
@@ -1034,29 +1063,47 @@ mod tests {
             dirs[0].clone(),
             r#"floats <= 3.2"#,
             &[3.2, 2.3, 1.4].map(|x| x.into()),
+            None,
         );
     }
 
     #[test]
-    fn test_e2e_operate_scalars() {
+    fn test_e2e_operations_scalars() {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
             r#"(2 + 3 - 4.5) * (5 / 2.3) % 1"#,
             &[0.0870].map(|x| x.into()),
+            None,
         );
     }
 
     #[test]
     fn test_e2e_sum_vector() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"sum(ints)"#, &[20i64].map(|x| x.into()));
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"sum(ints)"#,
+            &[20i64].map(|x| x.into()),
+            None,
+        );
     }
 
     #[test]
     fn test_e2e_sum_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"sum(ints < 0)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"sum(ints < 0)"#, &[], None);
+    }
+
+    #[test]
+    fn test_e2e_sum_over_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"sum(ints)[15ms]"#,
+            &[2i64, 10, 8].map(|x| x.into()),
+            Some(&[15u64, 30, 40]),
+        );
     }
 
     #[test]
@@ -1066,49 +1113,131 @@ mod tests {
             dirs[0].clone(),
             r#"count(uints)"#,
             &[4i64].map(|x| x.into()),
+            None,
         );
     }
 
     #[test]
     fn test_e2e_count_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"count(ints < 0)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"count(ints < 0)"#, &[], None);
+    }
+
+    #[test]
+    fn test_e2e_count_over_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"count(ints)[15ms]"#,
+            &[1i64, 2, 1].map(|x| x.into()),
+            Some(&[15u64, 30, 40]),
+        );
     }
 
     #[test]
     fn test_e2e_average_vector() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"avg(floats)"#, &[2.75].map(|x| x.into()));
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"avg(floats)"#,
+            &[2.75].map(|x| x.into()),
+            None,
+        );
     }
 
     #[test]
     fn test_e2e_average_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"avg(ints < 0)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"avg(ints < 0)"#, &[], None);
+    }
+
+    #[test]
+    fn test_e2e_average_over_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"avg(ints)[15ms]"#,
+            &[2.0, 5.0, 8.0].map(|x| x.into()),
+            Some(&[15u64, 30, 40]),
+        );
     }
 
     #[test]
     fn test_e2e_min_vector() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"min(ints)"#, &[2i64].map(|x| x.into()));
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"min(ints)"#,
+            &[2i64].map(|x| x.into()),
+            None,
+        );
     }
 
     #[test]
     fn test_e2e_min_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"min(ints < 0)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"min(ints < 0)"#, &[], None);
+    }
+
+    #[test]
+    fn test_e2e_min_over_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"min(ints)[15ms]"#,
+            &[2i64, 4, 8].map(|x| x.into()),
+            Some(&[15u64, 30, 40]),
+        );
     }
 
     #[test]
     fn test_e2e_max_vector() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"max(uints)"#, &[4u64].map(|x| x.into()));
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"max(uints)"#,
+            &[4u64].map(|x| x.into()),
+            None,
+        );
     }
 
     #[test]
     fn test_e2e_max_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"max(ints < 0)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"max(ints < 0)"#, &[], None);
+    }
+
+    #[test]
+    fn test_e2e_max_over_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"max(ints)[15ms]"#,
+            &[2i64, 6, 8].map(|x| x.into()),
+            Some(&[15u64, 30, 40]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_empty_subperiods() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"min(ints)[4ms]"#,
+            &[2i64, 4, 6, 8].map(|x| x.into()),
+            Some(&[12u64, 20, 32, 40]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_aggregate() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            r#"sum(count(ints)[4ms])"#,
+            &[4i64].map(|x| x.into()),
+            None,
+        );
     }
 
     #[test]
@@ -1118,6 +1247,7 @@ mod tests {
             dirs[0].clone(),
             r#"topk(2, ints)"#,
             &[8i64, 6].map(|x| x.into()),
+            None,
         );
     }
 
@@ -1128,13 +1258,14 @@ mod tests {
             dirs[0].clone(),
             r#"topk(100, uints)"#,
             &[4u64, 3, 2, 1].map(|x| x.into()),
+            None,
         );
     }
 
     #[test]
     fn test_e2e_topk_vector_zerok() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"topk(0, floats)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"topk(0, floats)"#, &[], None);
     }
 
     #[test]
@@ -1144,6 +1275,7 @@ mod tests {
             dirs[0].clone(),
             r#"bottomk(2, ints)"#,
             &[2i64, 4].map(|x| x.into()),
+            None,
         );
     }
 
@@ -1154,13 +1286,14 @@ mod tests {
             dirs[0].clone(),
             r#"bottomk(100, uints)"#,
             &[1u64, 2, 3, 4].map(|x| x.into()),
+            None,
         );
     }
 
     #[test]
     fn test_e2e_bottomk_vector_zerok() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"bottomk(0, floats)"#, &[]);
+        execution_test_helper(dirs[0].clone(), r#"bottomk(0, floats)"#, &[], None);
     }
 
     fn aggregate_test_helper(

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -1072,11 +1072,7 @@ mod tests {
     #[test]
     fn test_e2e_count_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(
-            dirs[0].clone(),
-            r#"count(ints < 0)"#,
-            &[0i64].map(|x| x.into()),
-        );
+        execution_test_helper(dirs[0].clone(), r#"count(ints < 0)"#, &[]);
     }
 
     #[test]

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -836,31 +836,31 @@ mod tests {
             let mut inserter =
                 create_stream_helper(&mut conn, r#"test_stream"#, ValueType::Integer64);
             for (t, v) in zip(timestamps, values) {
-                inserter.insert(*t, (*v).into());
+                inserter.insert(*t, (*v).into()).unwrap();
             }
-            inserter.flush();
+            inserter.flush().unwrap();
         } else {
             let timestamps = [0, 10, 20, 30, 40];
             let values = [10i64, 2, 4, 6, 8];
             let mut inserter = create_stream_helper(&mut conn, r#"ints"#, ValueType::Integer64);
             for (t, v) in zip(timestamps, values) {
-                inserter.insert(t, v.into());
+                inserter.insert(t, v.into()).unwrap();
             }
-            inserter.flush();
+            inserter.flush().unwrap();
 
             let values = [5u64, 1, 2, 3, 4];
             let mut inserter = create_stream_helper(&mut conn, r#"uints"#, ValueType::UInteger64);
             for (t, v) in zip(timestamps, values) {
-                inserter.insert(t, v.into());
+                inserter.insert(t, v.into()).unwrap();
             }
-            inserter.flush();
+            inserter.flush().unwrap();
 
             let values = [5.0, 4.1, 3.2, 2.3, 1.4];
             let mut inserter = create_stream_helper(&mut conn, r#"floats"#, ValueType::Float64);
             for (t, v) in zip(timestamps, values) {
-                inserter.insert(t, v.into());
+                inserter.insert(t, v.into()).unwrap();
             }
-            inserter.flush();
+            inserter.flush().unwrap();
         }
 
         let [start, end] = range.unwrap_or([0u64, 40]);
@@ -1412,9 +1412,9 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
-            None,
-            None,
-            r#"sum(ints < 0)[10ms]"#,
+            Some(&[]),
+            Some(&[]),
+            r#"sum(test_stream)[10ms]"#,
             None,
             &[],
             Some(&[]),

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -822,36 +822,49 @@ mod tests {
 
     fn execution_test_helper(
         root_dir: PathBuf,
+        timestamps: Option<&[Timestamp]>,
+        values: Option<&[i64]>,
         query: &str,
+        range: Option<[Timestamp; 2]>,
         expected: &[Value],
         expected_timestamps: Option<&[Timestamp]>,
     ) {
         let mut conn = Connection::new(root_dir).unwrap();
 
         // Insert dummy values
-        let timestamps = [0, 10, 20, 30, 40];
-        let values = [10i64, 2, 4, 6, 8];
-        let mut inserter = create_stream_helper(&mut conn, r#"ints"#, ValueType::Integer64);
-        for (t, v) in zip(timestamps, values) {
-            inserter.insert(t, v.into()).unwrap();
-        }
-        inserter.flush().unwrap();
+        if let (Some(timestamps), Some(values)) = (timestamps, values) {
+            let mut inserter =
+                create_stream_helper(&mut conn, r#"test_stream"#, ValueType::Integer64);
+            for (t, v) in zip(timestamps, values) {
+                inserter.insert(*t, (*v).into());
+            }
+            inserter.flush();
+        } else {
+            let timestamps = [0, 10, 20, 30, 40];
+            let values = [10i64, 2, 4, 6, 8];
+            let mut inserter = create_stream_helper(&mut conn, r#"ints"#, ValueType::Integer64);
+            for (t, v) in zip(timestamps, values) {
+                inserter.insert(t, v.into());
+            }
+            inserter.flush();
 
-        let values = [5u64, 1, 2, 3, 4];
-        let mut inserter = create_stream_helper(&mut conn, r#"uints"#, ValueType::UInteger64);
-        for (t, v) in zip(timestamps, values) {
-            inserter.insert(t, v.into()).unwrap();
-        }
-        inserter.flush().unwrap();
+            let values = [5u64, 1, 2, 3, 4];
+            let mut inserter = create_stream_helper(&mut conn, r#"uints"#, ValueType::UInteger64);
+            for (t, v) in zip(timestamps, values) {
+                inserter.insert(t, v.into());
+            }
+            inserter.flush();
 
-        let values = [5.0, 4.1, 3.2, 2.3, 1.4];
-        let mut inserter = create_stream_helper(&mut conn, r#"floats"#, ValueType::Float64);
-        for (t, v) in zip(timestamps, values) {
-            inserter.insert(t, v.into()).unwrap();
+            let values = [5.0, 4.1, 3.2, 2.3, 1.4];
+            let mut inserter = create_stream_helper(&mut conn, r#"floats"#, ValueType::Float64);
+            for (t, v) in zip(timestamps, values) {
+                inserter.insert(t, v.into());
+            }
+            inserter.flush();
         }
-        inserter.flush().unwrap();
 
-        let mut stmt = conn.prepare_query(query, Some(0), Some(40)).unwrap();
+        let [start, end] = range.unwrap_or([0u64, 40]);
+        let mut stmt = conn.prepare_query(query, Some(start), Some(end)).unwrap();
 
         // Process results
         let mut i: usize = 0;
@@ -895,7 +908,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints + floats"#,
+            None,
             &[15.0, 6.1, 7.2, 8.3, 9.4].map(|x| x.into()),
             None,
         );
@@ -906,7 +922,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints - uints"#,
+            None,
             &[5i64, 1, 2, 3, 4].map(|x| x.into()),
             None,
         );
@@ -917,7 +936,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints * floats"#,
+            None,
             &[50.0, 8.2, 12.8, 13.8, 11.2].map(|x| x.into()),
             None,
         );
@@ -928,7 +950,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints / uints"#,
+            None,
             &[2.0, 2.0, 2.0, 2.0, 2.0].map(|x| x.into()),
             None,
         );
@@ -939,7 +964,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints % floats"#,
+            None,
             &[0.0, 2.0, 0.8, 1.4, 1.0].map(|x| x.into()),
             None,
         );
@@ -950,7 +978,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints + 2"#,
+            None,
             &[12.0, 4.0, 6.0, 8.0, 10.0].map(|x| x.into()),
             None,
         );
@@ -961,7 +992,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"uints - 2.5"#,
+            None,
             &[2.5, -1.5, -0.5, 0.5, 1.5].map(|x| x.into()),
             None,
         );
@@ -972,7 +1006,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"floats * 11"#,
+            None,
             &[55.0, 45.1, 35.2, 25.3, 15.4].map(|x| x.into()),
             None,
         );
@@ -983,7 +1020,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"ints / -4"#,
+            None,
             &[-2.5, -0.5, -1.0, -1.5, -2.0].map(|x| x.into()),
             None,
         );
@@ -994,7 +1034,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"uints % 2"#,
+            None,
             &[1.0, 1.0, 0.0, 1.0, 0.0].map(|x| x.into()),
             None,
         );
@@ -1005,7 +1048,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"(ints % 4) == 2"#,
+            None,
             &[2.0, 2.0, 2.0].map(|x| x.into()),
             None,
         );
@@ -1016,7 +1062,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"uints != 2"#,
+            None,
             &[5i64, 1, 3, 4].map(|x| x.into()),
             None,
         );
@@ -1027,7 +1076,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"floats > 2.3"#,
+            None,
             &[5.0, 4.1, 3.2].map(|x| x.into()),
             None,
         );
@@ -1038,7 +1090,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"floats < 3.2"#,
+            None,
             &[2.3, 1.4].map(|x| x.into()),
             None,
         );
@@ -1049,7 +1104,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"floats >= 2.3"#,
+            None,
             &[5.0, 4.1, 3.2, 2.3].map(|x| x.into()),
             None,
         );
@@ -1060,7 +1118,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"floats <= 3.2"#,
+            None,
             &[3.2, 2.3, 1.4].map(|x| x.into()),
             None,
         );
@@ -1071,7 +1132,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"(2 + 3 - 4.5) * (5 / 2.3) % 1"#,
+            None,
             &[0.0870].map(|x| x.into()),
             None,
         );
@@ -1082,7 +1146,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"sum(ints)"#,
+            None,
             &[30i64].map(|x| x.into()),
             None,
         );
@@ -1091,7 +1158,15 @@ mod tests {
     #[test]
     fn test_e2e_sum_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"sum(ints < 0)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"sum(ints < 0)"#,
+            None,
+            &[],
+            None,
+        );
     }
 
     #[test]
@@ -1099,7 +1174,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"sum(ints)[15ms]"#,
+            None,
             &[12i64, 10, 8].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
@@ -1110,7 +1188,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"count(uints)"#,
+            None,
             &[5i64].map(|x| x.into()),
             None,
         );
@@ -1119,7 +1200,15 @@ mod tests {
     #[test]
     fn test_e2e_count_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"count(ints < 0)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"count(ints < 0)"#,
+            None,
+            &[0i64].map(|x| x.into()),
+            None,
+        );
     }
 
     #[test]
@@ -1127,7 +1216,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"count(ints)[15ms]"#,
+            None,
             &[2i64, 2, 1].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
@@ -1138,7 +1230,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"avg(floats)"#,
+            None,
             &[3.2].map(|x| x.into()),
             None,
         );
@@ -1147,7 +1242,15 @@ mod tests {
     #[test]
     fn test_e2e_average_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"avg(ints < 0)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"avg(ints < 0)"#,
+            None,
+            &[],
+            None,
+        );
     }
 
     #[test]
@@ -1155,7 +1258,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"avg(ints)[15ms]"#,
+            None,
             &[6.0, 5.0, 8.0].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
@@ -1166,7 +1272,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"min(ints)"#,
+            None,
             &[2i64].map(|x| x.into()),
             None,
         );
@@ -1175,7 +1284,15 @@ mod tests {
     #[test]
     fn test_e2e_min_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"min(ints < 0)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"min(ints < 0)"#,
+            None,
+            &[],
+            None,
+        );
     }
 
     #[test]
@@ -1183,7 +1300,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"min(ints)[15ms]"#,
+            None,
             &[2i64, 4, 8].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
@@ -1194,7 +1314,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"max(uints)"#,
+            None,
             &[5u64].map(|x| x.into()),
             None,
         );
@@ -1203,7 +1326,15 @@ mod tests {
     #[test]
     fn test_e2e_max_no_values() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"max(ints < 0)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"max(ints < 0)"#,
+            None,
+            &[],
+            None,
+        );
     }
 
     #[test]
@@ -1211,40 +1342,122 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"max(ints)[15ms]"#,
+            None,
             &[10i64, 6, 8].map(|x| x.into()),
             Some(&[15u64, 30, 40]),
         );
     }
 
     #[test]
-    fn test_e2e_aggregate_empty_subperiods() {
+    fn test_e2e_aggregate_subperiod_larger_than_stream() {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
-            r#"min(ints)[4ms]"#,
-            &[10i64, 2, 4, 6, 8].map(|x| x.into()),
-            Some(&[4u64, 12, 20, 32, 40]),
+            Some(&[0u64, 10, 20]),
+            Some(&[1i64, 2, 3]),
+            r#"sum(test_stream)[200ms]"#,
+            Some([5, 20]),
+            &[5i64].map(|x| x.into()),
+            Some(&[20u64]),
         );
     }
 
     #[test]
-    fn test_e2e_aggregate_aggregate() {
+    fn test_e2e_aggregate_subperiod_custom_start_end() {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            Some(&[0u64, 10, 20, 30, 40, 50]),
+            Some(&[1i64, 2, 3, 4, 5, 6]),
+            r#"sum(test_stream)[20ms]"#,
+            Some([6, 41]),
+            &[5i64, 9].map(|x| x.into()),
+            Some(&[26u64, 41]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_subperiod_consecutive_empty() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            Some(&[0u64, 5, 10, 25, 30, 65, 70]),
+            Some(&[1i64, 2, 3, 4, 5, 6, 7]),
+            r#"sum(test_stream)[10ms]"#,
+            Some([0, 70]),
+            &[6i64, 9, 13].map(|x| x.into()),
+            Some(&[10u64, 30, 70]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_count_subperiod_consecutive_empty() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            Some(&[0u64, 5, 10, 25, 30, 65, 70]),
+            Some(&[1i64, 2, 3, 4, 5, 6, 7]),
+            r#"count(test_stream)[10ms]"#,
+            Some([0, 70]),
+            &[3i64, 0, 2, 0, 0, 0, 2].map(|x| x.into()),
+            Some(&[10u64, 20, 30, 40, 50, 60, 70]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_subperiod_no_values() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"sum(ints < 0)[10ms]"#,
+            None,
+            &[],
+            Some(&[]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_subperiod_duplicate_timestamps() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            Some(&[0u64, 0, 10, 15, 15, 20, 30, 30]),
+            Some(&[1i64, 2, 3, 4, 5, 6, 7, 8]),
+            r#"sum(test_stream)[10ms]"#,
+            Some([0, 30]),
+            &[6i64, 15, 15].map(|x| x.into()),
+            Some(&[10u64, 20, 30]),
+        );
+    }
+
+    #[test]
+    fn test_e2e_aggregate_aggregate_subperiod() {
+        set_up_dirs!(dirs, "db");
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
             r#"sum(count(ints)[4ms])"#,
+            None,
             &[5i64].map(|x| x.into()),
             None,
         );
     }
 
     #[test]
-    fn test_e2e_aggregate_aggregate_over_subperiod() {
+    fn test_e2e_aggregate_subperiod_aggregate_subperiod() {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"sum(count(ints)[4ms])[16ms]"#,
+            None,
             &[2i64, 2, 1].map(|x| x.into()),
             Some(&[16u64, 32, 40]),
         );
@@ -1255,7 +1468,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"topk(2, ints)"#,
+            None,
             &[10i64, 8].map(|x| x.into()),
             None,
         );
@@ -1266,7 +1482,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"topk(100, uints)"#,
+            None,
             &[5u64, 4, 3, 2, 1].map(|x| x.into()),
             None,
         );
@@ -1275,7 +1494,15 @@ mod tests {
     #[test]
     fn test_e2e_topk_vector_zerok() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"topk(0, floats)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"topk(0, floats)"#,
+            None,
+            &[],
+            None,
+        );
     }
 
     #[test]
@@ -1283,7 +1510,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"bottomk(2, ints)"#,
+            None,
             &[2i64, 4].map(|x| x.into()),
             None,
         );
@@ -1294,7 +1524,10 @@ mod tests {
         set_up_dirs!(dirs, "db");
         execution_test_helper(
             dirs[0].clone(),
+            None,
+            None,
             r#"bottomk(100, uints)"#,
+            None,
             &[1u64, 2, 3, 4, 5].map(|x| x.into()),
             None,
         );
@@ -1303,7 +1536,15 @@ mod tests {
     #[test]
     fn test_e2e_bottomk_vector_zerok() {
         set_up_dirs!(dirs, "db");
-        execution_test_helper(dirs[0].clone(), r#"bottomk(0, floats)"#, &[], None);
+        execution_test_helper(
+            dirs[0].clone(),
+            None,
+            None,
+            r#"bottomk(0, floats)"#,
+            None,
+            &[],
+            None,
+        );
     }
 
     fn aggregate_test_helper(

--- a/tachyon_core/src/query/planner.rs
+++ b/tachyon_core/src/query/planner.rs
@@ -43,19 +43,46 @@ impl<'a> QueryPlanner<'a> {
                     parser::token::T_MAX => (AggregateType::Max, ScanHint::Max),
                     _ => unreachable!(),
                 };
+
                 Ok(TNode::Aggregate(AggregateNode::new(
                     aggregate_type,
-                    Box::new(self.handle_expr(&expr.expr, conn, scan_hint)?),
+                    expr.subperiod,
+                    self.start.unwrap(),
+                    self.end.unwrap(),
+                    Box::new(self.handle_expr(
+                        &expr.expr,
+                        conn,
+                        if expr.subperiod.is_some() {
+                            ScanHint::None
+                        } else {
+                            scan_hint
+                        },
+                    )?),
                     None,
                 )))
             }
             parser::token::T_AVG => Ok(TNode::Aggregate(AggregateNode::new(
                 AggregateType::Average,
-                Box::new(self.handle_expr(&expr.expr, conn, ScanHint::Sum)?),
+                expr.subperiod,
+                self.start.unwrap(),
+                self.end.unwrap(),
+                Box::new(self.handle_expr(
+                    &expr.expr,
+                    conn,
+                    if expr.subperiod.is_some() {
+                        ScanHint::None
+                    } else {
+                        ScanHint::Sum
+                    },
+                )?),
                 Some(Box::new(self.handle_expr(
                     &expr.expr,
                     conn,
-                    ScanHint::Count,
+                    if expr.subperiod.is_some() {
+                        ScanHint::None
+                    } else {
+                        ScanHint::Count
+                    },
                 )?)),
             ))),
             parser::token::T_BOTTOMK | parser::token::T_TOPK => {

--- a/tachyon_core/src/query/planner.rs
+++ b/tachyon_core/src/query/planner.rs
@@ -52,6 +52,7 @@ impl<'a> QueryPlanner<'a> {
                     Box::new(self.handle_expr(
                         &expr.expr,
                         conn,
+                        // Cannot use scanhint when aggregating over subperiods
                         if expr.subperiod.is_some() {
                             ScanHint::None
                         } else {
@@ -69,6 +70,7 @@ impl<'a> QueryPlanner<'a> {
                 Box::new(self.handle_expr(
                     &expr.expr,
                     conn,
+                    // Cannot use scanhint when aggregating over subperiods
                     if expr.subperiod.is_some() {
                         ScanHint::None
                     } else {
@@ -78,6 +80,7 @@ impl<'a> QueryPlanner<'a> {
                 Some(Box::new(self.handle_expr(
                     &expr.expr,
                     conn,
+                    // Cannot use scanhint when aggregating over subperiods
                     if expr.subperiod.is_some() {
                         ScanHint::None
                     } else {

--- a/tachyon_core/src/query/planner.rs
+++ b/tachyon_core/src/query/planner.rs
@@ -31,21 +31,6 @@ impl<'a> QueryPlanner<'a> {
         expr: &AggregateExpr,
         conn: &mut Connection,
     ) -> Result<TNode, QueryErr> {
-        let start = if let Some(start) = self.start {
-            start
-        } else {
-            return Err(QueryErr::StartEndTimeErr {
-                start_or_end: "start".to_string(),
-            });
-        };
-        let end = if let Some(end) = self.end {
-            end
-        } else {
-            return Err(QueryErr::StartEndTimeErr {
-                start_or_end: "end".to_string(),
-            });
-        };
-
         match expr.op.id() {
             parser::token::T_SUM
             | parser::token::T_COUNT
@@ -62,8 +47,8 @@ impl<'a> QueryPlanner<'a> {
                 Ok(TNode::Aggregate(AggregateNode::new(
                     aggregate_type,
                     expr.subperiod,
-                    start,
-                    end,
+                    self.start,
+                    self.end,
                     Box::new(self.handle_expr(
                         &expr.expr,
                         conn,
@@ -80,8 +65,8 @@ impl<'a> QueryPlanner<'a> {
             parser::token::T_AVG => Ok(TNode::Aggregate(AggregateNode::new(
                 AggregateType::Average,
                 expr.subperiod,
-                start,
-                end,
+                self.start,
+                self.end,
                 Box::new(self.handle_expr(
                     &expr.expr,
                     conn,

--- a/tachyon_core/src/query/planner.rs
+++ b/tachyon_core/src/query/planner.rs
@@ -31,6 +31,21 @@ impl<'a> QueryPlanner<'a> {
         expr: &AggregateExpr,
         conn: &mut Connection,
     ) -> Result<TNode, QueryErr> {
+        let start = if let Some(start) = self.start {
+            start
+        } else {
+            return Err(QueryErr::StartEndTimeErr {
+                start_or_end: "start".to_string(),
+            });
+        };
+        let end = if let Some(end) = self.end {
+            end
+        } else {
+            return Err(QueryErr::StartEndTimeErr {
+                start_or_end: "end".to_string(),
+            });
+        };
+
         match expr.op.id() {
             parser::token::T_SUM
             | parser::token::T_COUNT
@@ -47,8 +62,8 @@ impl<'a> QueryPlanner<'a> {
                 Ok(TNode::Aggregate(AggregateNode::new(
                     aggregate_type,
                     expr.subperiod,
-                    self.start.unwrap(),
-                    self.end.unwrap(),
+                    start,
+                    end,
                     Box::new(self.handle_expr(
                         &expr.expr,
                         conn,
@@ -65,8 +80,8 @@ impl<'a> QueryPlanner<'a> {
             parser::token::T_AVG => Ok(TNode::Aggregate(AggregateNode::new(
                 AggregateType::Average,
                 expr.subperiod,
-                self.start.unwrap(),
-                self.end.unwrap(),
+                start,
+                end,
                 Box::new(self.handle_expr(
                     &expr.expr,
                     conn,


### PR DESCRIPTION
### Description

[TAC-11](https://merms.atlassian.net/browse/TAC-11)

Implement aggregation by subperiod:

```
suppose linear = [(10, 4), (20, 2), (50, 3), (55, 5), (60, 2)]:
sum(linear) = 16
sum(linear)[30ms] = [(30, 6), (60, 10)]
sum(linear)[20ms] = [(20, 6), (60, 10)]  // No values between t=21 and t=40
count(linear)[10ms] = [(10, 1), (20, 1), (50, 1), (60, 2)]
```

- Subperiod duration is specified in square brackets after aggregation function

- Returns vector of values (instead of single scalar value) where `timestamp` is the end of subperiod and `value` is the aggregated value

- Skips subperiods with no values

- Implemented for `sum`, `count`, `avg`, `min`, `max`

### Handling subperiods with no values

I originally wanted to return a list of scalars but I couldn't think of a good way to deal with the "subperiods with no values" issue. Some ideas I had:

- **Skip empty subperiods**: eg. `sum(linear)[20ms] = [6, 10]`. Not a huge fan as the user might be expecting `n` values but receive less than `n` and have no way of knowing which values correspond to which subperiods.

- **Return a default value**: eg. `sum(linear)[20ms] = [6, 0, 10]`. This makes sense for `count` but there isn't really a sensible default value for the other aggregation functions.

- **Return a new `None` value**: eg. `sum(linear)[20ms] = [6, None, 10]`. This one makes the most sense but adding a new `None` type is a little complicated as functions like `next_scalar` and `next_vector` now have to be updated to return a new value type. Plus, we'd have to define `None`'s behaviour with other values (eg. should `None + 5` equal 5? throw an error?).

I ended up choosing to return a vector of values instead. This is essentially the `Skip empty subperiods` idea above, but making them vectors allows us to attach a timestamp to each value to avoid the missing gaps problem. As a bonus, it was relatively easy to implement `next_vector` as a wrapper around `next_scalar`.