### PR TITLE
Empty Header When Panic During Write

### DIFF
--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -1830,7 +1830,7 @@ mod tests {
                 create_stream_helper(&mut conn, r#"http_requests_total"#, ValueType::Float64);
 
             for i in 0..mid {
-                inserter.insert_float64(i, i as f64);
+                inserter.insert_float64(i, i as f64).unwrap();
             }
 
             panic!("Intentional panic to prevent Drop from running for inserter");
@@ -1843,9 +1843,9 @@ mod tests {
             let mut inserter = conn.prepare_insert(r#"http_requests_total"#);
 
             for i in mid..end {
-                inserter.insert_float64(i, i as f64);
+                inserter.insert_float64(i, i as f64).unwrap();
             }
-            inserter.flush();
+            inserter.flush().unwrap();
         }
     }
 }

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -1815,4 +1815,40 @@ mod tests {
             assert!(avgquery.next_scalar().is_none());
         }
     }
+
+    #[test]
+    fn test_multiple_writes_to_same_stream_recovers_after_panic() {
+        set_up_dirs!(dirs, "db");
+        let root_dir = dirs[0].clone();
+
+        let mid = 60;
+        let end = 200;
+        
+        let result = std::panic::catch_unwind(|| {
+            let mut conn = Connection::new(&root_dir).unwrap();
+            let mut inserter = create_stream_helper(
+                &mut conn,
+                r#"http_requests_total"#,
+                ValueType::Float64,
+            );
+        
+            for i in 0..mid as u64 {
+                inserter.insert_float64(i, 1.0 as f64);
+            }
+        
+            panic!("Intentional panic to prevent Drop from running for inserter");
+        });
+        
+        assert!(result.is_err(), "Expected a panic but didn't get one");
+        
+        {
+            let mut conn = Connection::new(&root_dir).unwrap();
+            let mut inserter = conn.prepare_insert(r#"http_requests_total"#);
+        
+            for i in mid..end {
+                inserter.insert_float64(i, 1.0 as f64);
+            }
+            inserter.flush();
+        }
+    }
 }

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -1829,8 +1829,8 @@ mod tests {
             let mut inserter =
                 create_stream_helper(&mut conn, r#"http_requests_total"#, ValueType::Float64);
 
-            for i in 0..mid as u64 {
-                inserter.insert_float64(i, 1.0 as f64);
+            for i in 0..mid {
+                inserter.insert_float64(i, i as f64);
             }
 
             panic!("Intentional panic to prevent Drop from running for inserter");
@@ -1843,7 +1843,7 @@ mod tests {
             let mut inserter = conn.prepare_insert(r#"http_requests_total"#);
 
             for i in mid..end {
-                inserter.insert_float64(i, 1.0 as f64);
+                inserter.insert_float64(i, i as f64);
             }
             inserter.flush();
         }

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -1823,28 +1823,25 @@ mod tests {
 
         let mid = 60;
         let end = 200;
-        
+
         let result = std::panic::catch_unwind(|| {
             let mut conn = Connection::new(&root_dir).unwrap();
-            let mut inserter = create_stream_helper(
-                &mut conn,
-                r#"http_requests_total"#,
-                ValueType::Float64,
-            );
-        
+            let mut inserter =
+                create_stream_helper(&mut conn, r#"http_requests_total"#, ValueType::Float64);
+
             for i in 0..mid as u64 {
                 inserter.insert_float64(i, 1.0 as f64);
             }
-        
+
             panic!("Intentional panic to prevent Drop from running for inserter");
         });
-        
+
         assert!(result.is_err(), "Expected a panic but didn't get one");
-        
+
         {
             let mut conn = Connection::new(&root_dir).unwrap();
             let mut inserter = conn.prepare_insert(r#"http_requests_total"#);
-        
+
             for i in mid..end {
                 inserter.insert_float64(i, 1.0 as f64);
             }

--- a/tachyon_core/src/storage/file.rs
+++ b/tachyon_core/src/storage/file.rs
@@ -147,6 +147,7 @@ impl Header {
     fn write_from_path(&self, path: &PathBuf) -> Result<usize, io::Error> {
         let mut file = OpenOptions::new()
             .create(true)
+            .truncate(true) // may be the case that this file already exists due to previous panic!
             .write(true)
             .open(path)
             .unwrap();

--- a/tachyon_core/src/storage/file.rs
+++ b/tachyon_core/src/storage/file.rs
@@ -149,8 +149,7 @@ impl Header {
             .create(true)
             .truncate(true) // may be the case that this file already exists due to previous panic!
             .write(true)
-            .open(path)
-            .unwrap();
+            .open(path)?;
 
         self.write(&mut file)
     }
@@ -544,7 +543,7 @@ impl PartiallyPersistentDataFile {
 
     pub fn lazy_init(mut self, ts: Timestamp, v: Value) -> Result<Self, WriterErr> {
         self.update_header(ts, v);
-        self.header.borrow().write_from_path(&self.path).unwrap();
+        self.header.borrow().write_from_path(&self.path)?;
         let writer = PartiallyPersistentDataFileWriter::new(self.header.clone(), &(self.path));
         self.compressor = Option::Some(IntCompressor::new(writer, &self.header.borrow().clone()));
 

--- a/tachyon_core/src/storage/file.rs
+++ b/tachyon_core/src/storage/file.rs
@@ -144,6 +144,16 @@ impl Header {
         Ok(8)
     }
 
+    fn write_from_path(&self, path: &PathBuf) -> Result<usize, io::Error> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+
+        self.write(&mut file)
+    }
+
     fn write(&self, file: &mut File) -> Result<usize, io::Error> {
         file.write_all(&MAGIC)?;
 
@@ -533,6 +543,7 @@ impl PartiallyPersistentDataFile {
 
     pub fn lazy_init(mut self, ts: Timestamp, v: Value) -> Result<Self, WriterErr> {
         self.update_header(ts, v);
+        self.header.borrow().write_from_path(&self.path).unwrap();
         let writer = PartiallyPersistentDataFileWriter::new(self.header.clone(), &(self.path));
         self.compressor = Option::Some(IntCompressor::new(writer, &self.header.borrow().clone()));
 

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -20,8 +20,14 @@ pub struct PersistentWriter {
 
 impl PersistentWriter {
     fn derive_file_path(root: impl AsRef<Path>, stream_id: Uuid, ts: Timestamp) -> PathBuf {
-        root.as_ref()
-            .join(format!("{}/{}.{}", stream_id, ts, FILE_EXTENSION))
+        let uuid = Uuid::new_v4();
+        root.as_ref().join(format!(
+            "{}/{}-{}.{}",
+            stream_id,
+            ts,
+            uuid,
+            FILE_EXTENSION
+        ))
     }
 
     fn create_or_open_file(
@@ -64,9 +70,6 @@ impl PersistentWriter {
             }
 
             let file_path = PersistentWriter::derive_file_path(&self.root, stream_id, ts);
-            self.indexer
-                .borrow_mut()
-                .insert_new_file(stream_id, &file_path, ts, None)?;
 
             let file = PartiallyPersistentDataFile::new(
                 self.version,
@@ -78,8 +81,7 @@ impl PersistentWriter {
 
             self.indexer
                 .borrow_mut()
-                .insert_new_file(stream_id, &file_path, ts, None)
-                .unwrap();
+                .insert_new_file(stream_id, &file_path, ts, None)?;
 
             file
         }
@@ -175,10 +177,15 @@ mod tests {
                 .into_string()
                 .unwrap();
 
-            let suffix_opt = path
-                .rsplit('/')
-                .next()
-                .and_then(|num_str| num_str.split('.').next().unwrap().parse::<u32>().ok());
+            let suffix_opt = path.rsplit('/').next().and_then(|num_str| {
+                num_str
+                    .split('.')
+                    .next()
+                    .and_then(|num_str| num_str.split('-').next())
+                    .unwrap()
+                    .parse::<u32>()
+                    .ok()
+            });
 
             suffix_opt.expect("Expected file suffix to be u32")
         }

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -68,13 +68,20 @@ impl PersistentWriter {
                 .borrow_mut()
                 .insert_new_file(stream_id, &file_path, ts, None)?;
 
-            PartiallyPersistentDataFile::new(
+            let file = PartiallyPersistentDataFile::new(
                 self.version,
                 StreamId(stream_id.as_u128()),
                 value_type,
                 file_path.clone(),
             )
-            .lazy_init(ts, v)
+            .lazy_init(ts, v);
+
+            self.indexer
+                .borrow_mut()
+                .insert_new_file(stream_id, &file_path, ts, None)
+                .unwrap();
+
+            file
         }
     }
 }

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -21,13 +21,8 @@ pub struct PersistentWriter {
 impl PersistentWriter {
     fn derive_file_path(root: impl AsRef<Path>, stream_id: Uuid, ts: Timestamp) -> PathBuf {
         let uuid = Uuid::new_v4();
-        root.as_ref().join(format!(
-            "{}/{}-{}.{}",
-            stream_id,
-            ts,
-            uuid,
-            FILE_EXTENSION
-        ))
+        root.as_ref()
+            .join(format!("{}/{}-{}.{}", stream_id, ts, uuid, FILE_EXTENSION))
     }
 
     fn create_or_open_file(
@@ -77,13 +72,13 @@ impl PersistentWriter {
                 value_type,
                 file_path.clone(),
             )
-            .lazy_init(ts, v);
+            .lazy_init(ts, v)?;
 
             self.indexer
                 .borrow_mut()
                 .insert_new_file(stream_id, &file_path, ts, None)?;
 
-            file
+            Ok(file)
         }
     }
 }


### PR DESCRIPTION
### Case 1
- Edge case 1: if there is a panic before the first chunk is persisted then there would be no header in our .ty files. This would cause the partial init to fail as the file is empty.
- Fix: when the partially persistent file is created in memory (and before inserted in the indexer), the header is written to disk at the start to prevent this edge case.

### Case 2
- Edge case 2: previously we generated `.ty` files based on the first timestamp in the file. The user could theoretically write items with the same timestamp over and over. This means that we would overwrite the same file in this scenario
- Fix: modify the file name to append a random `uuid` to the end. The odds of collision are astronomically low with this fix. An example file name is `stream/{ts}-{uuid}.ty`
- Tradeoff: if we create the file in the writer and a crash happens before the filename is inserted in the indexer than we may have a random unused file. However the odds of this are extremely low so this seems like an acceptable tradeoff at this point.