### PR TITLE
feat: Insert benchmark

### DIFF
--- a/tachyon_core/Cargo.toml
+++ b/tachyon_core/Cargo.toml
@@ -18,6 +18,10 @@ name = "query"
 harness = false
 
 [[bench]]
+name = "insert"
+harness = false
+
+[[bench]]
 name = "read"
 harness = false
 

--- a/tachyon_core/benches/insert.rs
+++ b/tachyon_core/benches/insert.rs
@@ -4,7 +4,7 @@ use pprof::{
     criterion::{Output, PProfProfiler},
     flamegraph::Options,
 };
-use std::{fs, path::PathBuf, str::FromStr};
+use std::{fs, hint::black_box, path::PathBuf, str::FromStr};
 use tachyon_core::{Connection, ValueType};
 
 const STREAM: &str = r#"inserter_stream{service = "web"}"#;
@@ -25,14 +25,16 @@ fn read_from_csv(path: &str) -> (Vec<u64>, Vec<u64>) {
     (timestamps, values)
 }
 
-fn bench_insert(conn: &mut Connection, timestamps: &Vec<u64>, values: &Vec<u64>) {
-    let mut inserter = conn.prepare_insert(STREAM);
+fn bench_insert(conn: &mut Connection, timestamps: &[u64], values: &[u64]) {
+    let mut inserter = black_box(conn.prepare_insert(STREAM));
 
     for i in 0..timestamps.len() {
-        inserter.insert_uinteger64(timestamps[i], values[i]);
+        inserter
+            .insert_uinteger64(timestamps[i], values[i])
+            .unwrap();
     }
 
-    inserter.flush();
+    inserter.flush().unwrap();
 }
 
 fn insert_benchmark(c: &mut Criterion) {
@@ -48,14 +50,14 @@ fn insert_benchmark(c: &mut Criterion) {
             fs::remove_dir_all(root_dir.clone()).unwrap();
         })
     });
-
-    fs::remove_dir_all(root_dir.clone()).unwrap();
 }
 
 fn get_config() -> Criterion {
     let mut options = Options::default();
     options.flame_chart = true;
-    Criterion::default().with_profiler(PProfProfiler::new(10000, Output::Flamegraph(Some(options))))
+    Criterion::default()
+        .sample_size(20)
+        .with_profiler(PProfProfiler::new(10000, Output::Flamegraph(Some(options))))
 }
 
 criterion_group!(

--- a/tachyon_core/benches/insert.rs
+++ b/tachyon_core/benches/insert.rs
@@ -1,0 +1,66 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use csv::Reader;
+use pprof::{
+    criterion::{Output, PProfProfiler},
+    flamegraph::Options,
+};
+use std::{fs, path::PathBuf, str::FromStr};
+use tachyon_core::{Connection, ValueType};
+
+const STREAM: &str = r#"inserter_stream{service = "web"}"#;
+
+fn read_from_csv(path: &str) -> (Vec<u64>, Vec<u64>) {
+    println!("Reading from: {}", path);
+    let mut rdr = Reader::from_path(path).unwrap();
+
+    let mut timestamps = Vec::new();
+    let mut values = Vec::new();
+    for result in rdr.records() {
+        let record = result.unwrap();
+        timestamps.push(record[0].parse::<u64>().unwrap());
+        values.push(record[1].parse::<u64>().unwrap());
+    }
+    println!("Done reading from: {}\n", path);
+
+    (timestamps, values)
+}
+
+fn bench_insert(conn: &mut Connection, timestamps: &Vec<u64>, values: &Vec<u64>) {
+    let mut inserter = conn.prepare_insert(STREAM);
+
+    for i in 0..timestamps.len() {
+        inserter.insert_uinteger64(timestamps[i], values[i]);
+    }
+
+    inserter.flush();
+}
+
+fn insert_benchmark(c: &mut Criterion) {
+    let root_dir = PathBuf::from_str("../tmp").unwrap();
+
+    let (timestamps, values) = read_from_csv("../data/voltage_dataset.csv");
+
+    c.bench_function("tachyon: insert benchmark", |b| {
+        b.iter(|| {
+            let mut conn = Connection::new(root_dir.clone()).unwrap();
+            conn.create_stream(STREAM, ValueType::UInteger64).unwrap();
+            bench_insert(&mut conn, &timestamps, &values);
+            fs::remove_dir_all(root_dir.clone()).unwrap();
+        })
+    });
+
+    fs::remove_dir_all(root_dir.clone()).unwrap();
+}
+
+fn get_config() -> Criterion {
+    let mut options = Options::default();
+    options.flame_chart = true;
+    Criterion::default().with_profiler(PProfProfiler::new(10000, Output::Flamegraph(Some(options))))
+}
+
+criterion_group!(
+    name = insert_benches;
+    config = get_config();
+    targets = insert_benchmark,
+);
+criterion_main!(insert_benches);


### PR DESCRIPTION
### Description

Adds a benchmark for insert code. This benchmark isn't entirely accurate since it includes some setup and deletion code, but it should be good enough to represent insertion time with a large enough dataset (i.e. `voltage_dataset.csv`).

I tried using CLI parameters for criterion instead of hard-coding the path to the dataset (and possibly using the same code for the query benchmark too) but it doesn't seem like that works.