### PR TITLE
[BUG FIX] Change Paths Stored in Indexer

### DIFF
--- a/tachyon_core/src/execution/node/vector_select.rs
+++ b/tachyon_core/src/execution/node/vector_select.rs
@@ -50,7 +50,7 @@ impl VectorSelectNode {
         let file_paths = conn
             .indexer
             .borrow()
-            .get_required_files(stream_id, start, end)
+            .get_physical_required_files(stream_id, start, end)
             .unwrap();
 
         Ok(Self {
@@ -90,7 +90,7 @@ impl ExecutorNode for VectorSelectNode {
             let file_paths = self
                 .indexer
                 .borrow()
-                .get_required_files(stream_id, self.start, self.end)
+                .get_physical_required_files(stream_id, self.start, self.end)
                 .unwrap();
 
             self.cursor = Cursor::new(

--- a/tachyon_core/src/query/indexer.rs
+++ b/tachyon_core/src/query/indexer.rs
@@ -40,6 +40,12 @@ trait IndexerStore {
         start: Timestamp,
         end: Timestamp,
     ) -> Result<Vec<PathBuf>, IndexerErr>;
+    fn get_physical_files_for_stream_id(
+        &self,
+        stream_id: Uuid,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Result<Vec<PathBuf>, IndexerErr>;
     fn get_open_files_for_stream_id(&self, stream_id: Uuid) -> Result<Vec<PathBuf>, IndexerErr>;
     fn get_max_timestamp(&self, stream_id: Uuid) -> Result<Option<Timestamp>, IndexerErr>;
 }
@@ -51,6 +57,7 @@ mod sqlite {
 
     pub struct SQLiteIndexerStore {
         conn: Connection,
+        root: PathBuf,
     }
 
     impl SQLiteIndexerStore {
@@ -66,6 +73,7 @@ mod sqlite {
         pub fn new(root_dir: impl AsRef<Path>) -> Result<Self, IndexerErr> {
             Ok(Self {
                 conn: Connection::open(root_dir.as_ref().join(Self::SQLITE_DB_NAME))?,
+                root: root_dir.as_ref().to_path_buf(),
             })
         }
     }
@@ -343,6 +351,28 @@ mod sqlite {
             Ok(rows.map(|item| item.unwrap().into()).collect())
         }
 
+        fn get_physical_files_for_stream_id(
+            &self,
+            stream_id: Uuid,
+            start: Timestamp,
+            end: Timestamp,
+        ) -> Result<Vec<PathBuf>, IndexerErr> {
+            let mut stmt = self.conn.prepare_cached(&format!(
+                "SELECT filename FROM {} WHERE id = ? AND (? <= end OR end IS NULL) AND ? >= start ORDER BY start ASC",
+                Self::SQLITE_ID_TO_FILENAME_TABLE
+            ))?;
+
+            // SAFETY: the row.get call will only fail if we generated the table wrong, which is bad
+            let rows = stmt.query_map((stream_id, start, end), |row| {
+                Ok(row
+                    .get::<usize, String>(0)
+                    .expect("ID to Filename: row not valid at idx 0."))
+            })?;
+
+            // SAFETY: this will always be Ok based on implementation of .query_map above
+            Ok(rows.map(|item| self.root.join(item.unwrap())).collect())
+        }
+
         fn get_value_type_for_stream_id(&self, stream_id: Uuid) -> Option<ValueType> {
             self.conn
                 .query_row(
@@ -541,6 +571,16 @@ impl Indexer {
         end: Timestamp,
     ) -> Result<Vec<PathBuf>, IndexerErr> {
         self.store.get_files_for_stream_id(stream_id, start, end)
+    }
+
+    pub fn get_physical_required_files(
+        &self,
+        stream_id: Uuid,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Result<Vec<PathBuf>, IndexerErr> {
+        self.store
+            .get_physical_files_for_stream_id(stream_id, start, end)
     }
 
     pub fn get_open_files_for_stream_id(

--- a/tachyon_core/src/storage/file.rs
+++ b/tachyon_core/src/storage/file.rs
@@ -537,7 +537,8 @@ impl TimeDataFile {
 
 pub struct PartiallyPersistentDataFile {
     pub header: Rc<RefCell<Header>>,
-    pub path: PathBuf,
+    pub physical_path: PathBuf,
+    pub virtual_path: PathBuf,
     compressor: Option<IntCompressor<PartiallyPersistentDataFileWriter>>,
 }
 
@@ -546,28 +547,31 @@ impl PartiallyPersistentDataFile {
         version: Version,
         stream_id: StreamId,
         value_type: ValueType,
-        path: PathBuf,
+        physical_path: PathBuf,
+        virtual_path: PathBuf,
     ) -> Self {
         let header = Rc::new(RefCell::new(Header::new(version, stream_id, value_type)));
 
         Self {
             header,
-            path,
+            physical_path,
+            virtual_path,
             compressor: None,
         }
     }
 
     pub fn lazy_init(mut self, ts: Timestamp, v: Value) -> Result<Self, WriterErr> {
         self.update_header(ts, v);
-        self.header.borrow().write_from_path(&self.path)?;
-        let writer = PartiallyPersistentDataFileWriter::new(self.header.clone(), &(self.path));
+        self.header.borrow().write_from_path(&self.physical_path)?;
+        let writer =
+            PartiallyPersistentDataFileWriter::new(self.header.clone(), &(self.physical_path));
         self.compressor = Option::Some(IntCompressor::new(writer, &self.header.borrow().clone()));
 
         Ok(self)
     }
 
     pub fn partial_init(mut self, ts: Timestamp, v: Value) -> Result<Self, WriterErr> {
-        let data_file = TimeDataFile::read_data_file(self.path.clone());
+        let data_file = TimeDataFile::read_data_file(self.physical_path.clone());
         self.header = Rc::new(RefCell::new(data_file.header.clone()));
 
         if ts < self.header.borrow().max_timestamp {
@@ -577,7 +581,8 @@ impl PartiallyPersistentDataFile {
             });
         }
 
-        let writer = PartiallyPersistentDataFileWriter::new(self.header.clone(), &(self.path));
+        let writer =
+            PartiallyPersistentDataFileWriter::new(self.header.clone(), &(self.physical_path));
         self.compressor = Option::Some(IntCompressor::new_from_partial(writer, data_file));
 
         self.write(ts, v)?;

--- a/tachyon_core/src/storage/writer/in_memory_writer.rs
+++ b/tachyon_core/src/storage/writer/in_memory_writer.rs
@@ -42,21 +42,22 @@ impl InMemoryWriter {
             entries_written += file.write_batch_data_to_file_in_mem(&batch[entries_written..]);
 
             if file.num_entries() >= MAX_NUM_ENTRIES {
-                file.write(InMemoryWriter::derive_file_path(
-                    &(self.root),
-                    stream_id,
-                    file,
-                ));
+                let physical_path = self
+                    .root
+                    .join(InMemoryWriter::create_virtual_file_path(stream_id, file));
+                file.write(physical_path);
                 self.open_data_files.remove_entry(&stream_id);
             }
         }
     }
 
-    fn derive_file_path(root: impl AsRef<Path>, stream_id: Uuid, file: &TimeDataFile) -> PathBuf {
-        root.as_ref().join(format!(
-            "{}/{}.{}",
+    fn create_virtual_file_path(stream_id: Uuid, file: &TimeDataFile) -> PathBuf {
+        let uuid = Uuid::new_v4();
+        PathBuf::from(format!(
+            "{}/{}-{}.{}",
             stream_id,
             file.get_file_name(),
+            uuid,
             FILE_EXTENSION
         ))
     }
@@ -90,12 +91,14 @@ impl Writer for InMemoryWriter {
 
         file.write_data_to_file_in_mem(ts, v);
         if file.num_entries() >= MAX_NUM_ENTRIES {
-            let file_path = InMemoryWriter::derive_file_path(&self.root, stream_id, file);
-            file.write(file_path.clone());
+            let virtual_path = InMemoryWriter::create_virtual_file_path(stream_id, file);
+            let physical_path = self.root.join(&virtual_path);
+
+            file.write(physical_path);
             // TODO: remove unwrap
             self.indexer.borrow_mut().insert_new_file(
                 stream_id,
-                &file_path,
+                &virtual_path,
                 file.header.min_timestamp,
                 Some(file.header.max_timestamp),
             )?;
@@ -114,7 +117,7 @@ impl Writer for InMemoryWriter {
 
     fn flush_all(&mut self) -> Result<(), WriterErr> {
         for (stream_id, file) in self.open_data_files.iter_mut() {
-            let file_path = InMemoryWriter::derive_file_path(&self.root, *stream_id, file);
+            let file_path = InMemoryWriter::create_virtual_file_path(*stream_id, file);
             file.write(file_path.clone());
             // TODO: remove unwrap
             self.indexer.borrow_mut().insert_new_file(
@@ -160,10 +163,15 @@ mod tests {
                 .into_string()
                 .unwrap();
 
-            let suffix_opt = path
-                .rsplit('/')
-                .next()
-                .and_then(|num_str| num_str.split('.').next().unwrap().parse::<u32>().ok());
+            let suffix_opt = path.rsplit('/').next().and_then(|num_str| {
+                num_str
+                    .split('.')
+                    .next()
+                    .and_then(|num_str| num_str.split('-').next())
+                    .unwrap()
+                    .parse::<u32>()
+                    .ok()
+            });
 
             suffix_opt.expect("Expected file suffix to be u32")
         }

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -12,17 +12,16 @@ use std::rc::Rc;
 use uuid::Uuid;
 
 pub struct PersistentWriter {
-    open_data_files: HashMap<Uuid, PartiallyPersistentDataFile>, // Stream ID to in-mem file
+    partial_data_files: HashMap<Uuid, PartiallyPersistentDataFile>, // Stream ID to in-mem file
     root: PathBuf,
     indexer: Rc<RefCell<Indexer>>,
     version: Version,
 }
 
 impl PersistentWriter {
-    fn derive_file_path(root: impl AsRef<Path>, stream_id: Uuid, ts: Timestamp) -> PathBuf {
+    fn create_virtual_file_path(stream_id: Uuid, ts: Timestamp) -> PathBuf {
         let uuid = Uuid::new_v4();
-        root.as_ref()
-            .join(format!("{}/{}-{}.{}", stream_id, ts, uuid, FILE_EXTENSION))
+        PathBuf::from(format!("{}/{}-{}.{}", stream_id, ts, uuid, FILE_EXTENSION))
     }
 
     fn create_or_open_file(
@@ -32,24 +31,26 @@ impl PersistentWriter {
         v: Value,
         value_type: ValueType,
     ) -> Result<PartiallyPersistentDataFile, WriterErr> {
-        let open_file = self
+        let open_files = self
             .indexer
             .borrow()
             .get_open_files_for_stream_id(stream_id)?;
 
         assert!(
-            open_file.len() <= 1,
+            open_files.len() <= 1,
             "Invalid state! Multiple open files for the stream {}.",
             stream_id
         );
 
-        if open_file.len() == 1 {
-            let file_path = &open_file[0];
+        if open_files.len() == 1 {
+            let virtual_path = &open_files[0];
+            let physical_path = self.root.join(virtual_path);
             PartiallyPersistentDataFile::new(
                 self.version,
                 StreamId(stream_id.as_u128()),
                 value_type,
-                file_path.clone(),
+                physical_path,
+                virtual_path.clone(),
             )
             .partial_init(ts, v)
         } else {
@@ -64,19 +65,21 @@ impl PersistentWriter {
                 }
             }
 
-            let file_path = PersistentWriter::derive_file_path(&self.root, stream_id, ts);
+            let virtual_path = PersistentWriter::create_virtual_file_path(stream_id, ts);
+            let physical_path = self.root.join(&virtual_path);
 
             let file = PartiallyPersistentDataFile::new(
                 self.version,
                 StreamId(stream_id.as_u128()),
                 value_type,
-                file_path.clone(),
+                physical_path,
+                virtual_path.clone(),
             )
             .lazy_init(ts, v)?;
 
             self.indexer
                 .borrow_mut()
-                .insert_new_file(stream_id, &file_path, ts, None)?;
+                .insert_new_file(stream_id, &virtual_path, ts, None)?;
 
             Ok(file)
         }
@@ -86,7 +89,7 @@ impl PersistentWriter {
 impl Writer for PersistentWriter {
     fn new(root: impl AsRef<Path>, indexer: Rc<RefCell<Indexer>>, version: Version) -> Self {
         PersistentWriter {
-            open_data_files: HashMap::new(),
+            partial_data_files: HashMap::new(),
             root: root.as_ref().to_path_buf(),
             indexer,
             version,
@@ -100,41 +103,41 @@ impl Writer for PersistentWriter {
         v: Value,
         value_type: ValueType,
     ) -> Result<(), WriterErr> {
-        if let Some(file) = self.open_data_files.get_mut(&stream_id) {
+        if let Some(file) = self.partial_data_files.get_mut(&stream_id) {
             // Use the existing file if available
             file.write(ts, v)?; // will return err if out of order
             if file.num_entries() >= MAX_NUM_ENTRIES {
                 file.flush()?;
                 self.indexer.borrow_mut().insert_or_replace_file(
                     stream_id,
-                    &file.path,
+                    &file.virtual_path,
                     file.header.borrow().min_timestamp,
                     file.header.borrow().max_timestamp,
                 )?;
-                self.open_data_files.remove_entry(&stream_id);
+                self.partial_data_files.remove_entry(&stream_id);
             }
             Ok(())
         } else {
             let file: PartiallyPersistentDataFile =
                 self.create_or_open_file(stream_id, ts, v, value_type)?;
-            self.open_data_files.insert(stream_id, file);
+            self.partial_data_files.insert(stream_id, file);
             Ok(())
         }
     }
 
     fn flush_all(&mut self) -> Result<(), WriterErr> {
-        for (stream_id, file) in self.open_data_files.iter_mut() {
+        for (stream_id, file) in self.partial_data_files.iter_mut() {
             file.flush()?;
             // TODO: we can have files that aren't the max number of entries
             // We need to decompress the partial file and then do some logic to complete any unfinished chunk at the end of the file
             self.indexer.borrow_mut().insert_or_replace_file(
                 *stream_id,
-                &file.path,
+                &file.virtual_path,
                 file.header.borrow().min_timestamp,
                 file.header.borrow().max_timestamp,
             )?;
         }
-        self.open_data_files.clear();
+        self.partial_data_files.clear();
         Ok(())
     }
 


### PR DESCRIPTION
We previously stored the relative path to files in our database in the indexer. For example `../dir/some_dir/database/stream/file.ty`. This means that when we move the folder the directory is hosted in or if we try to run the executable from a different directory things will break as the file path is now different relative to where we are executing.

Fix:
- The writer's now only store `stream/file.ty`. The indexer can now return the "physical path" by returning the "virtual path" joined with the root directory.