### PR TITLE
Error handling for lib.rs

### DIFF
--- a/tachyon_cli/src/handlers/commands/mod.rs
+++ b/tachyon_cli/src/handlers/commands/mod.rs
@@ -68,13 +68,12 @@ pub fn handle_command(
             stream,
             create,
         } => {
-            if create && !connection.check_stream_exists(&stream) {
+            if create && !connection.check_stream_exists(&stream)? {
                 connection
-                    .create_stream(&stream, config.value_type)
-                    .unwrap();
+                    .create_stream(&stream, config.value_type)?;
             }
 
-            let mut inserter = connection.prepare_insert(&stream);
+            let mut inserter = connection.prepare_insert(&stream)?;
             println!("Reading from: {:?}", &path);
 
             let vectors = input::vector_input(&path, config.value_type)?;

--- a/tachyon_cli/src/handlers/commands/mod.rs
+++ b/tachyon_cli/src/handlers/commands/mod.rs
@@ -99,7 +99,7 @@ pub fn handle_command(
             Ok(())
         }
         TachyonCommand::Create { stream } => {
-            connection.create_stream(stream, config.value_type).unwrap();
+            connection.create_stream(stream, config.value_type)?;
             Ok(())
         }
         TachyonCommand::Exit => {

--- a/tachyon_cli/src/handlers/commands/mod.rs
+++ b/tachyon_cli/src/handlers/commands/mod.rs
@@ -69,8 +69,7 @@ pub fn handle_command(
             create,
         } => {
             if create && !connection.check_stream_exists(&stream)? {
-                connection
-                    .create_stream(&stream, config.value_type)?;
+                connection.create_stream(&stream, config.value_type)?;
             }
 
             let mut inserter = connection.prepare_insert(&stream)?;

--- a/tachyon_cli/src/main.rs
+++ b/tachyon_cli/src/main.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum CLIErr {
+    #[error(transparent)]
+    TachyonErr(#[from] TachyonErr),
     #[error("Input '{input}' could not be converted to stream type = {value_type}.")]
     InputValueTypeErr {
         input: String,
@@ -28,8 +30,6 @@ pub enum CLIErr {
     ReadLineErr(#[from] ReadlineError),
     #[error("IO Error.")]
     FileIOErr(#[from] std::io::Error),
-    #[error(transparent)]
-    TachyonErr(#[from] TachyonErr),
     #[error("Unsupported file format #{extension}.")]
     UnsupportedFileErr { extension: String },
 }

--- a/tachyon_core/benches/insert.rs
+++ b/tachyon_core/benches/insert.rs
@@ -26,7 +26,7 @@ fn read_from_csv(path: &str) -> (Vec<u64>, Vec<u64>) {
 }
 
 fn bench_insert(conn: &mut Connection, timestamps: &[u64], values: &[u64]) {
-    let mut inserter = black_box(conn.prepare_insert(STREAM));
+    let mut inserter = black_box(conn.prepare_insert(STREAM).unwrap());
 
     for i in 0..timestamps.len() {
         inserter

--- a/tachyon_core/benches/query.rs
+++ b/tachyon_core/benches/query.rs
@@ -62,13 +62,13 @@ fn vector_selector_benchmark(c: &mut Criterion) {
 
     let mut conn = Connection::new(root_dir.clone()).unwrap();
 
-    if !conn.check_stream_exists(STREAM) {
+    if !conn.check_stream_exists(STREAM).unwrap() {
         conn.create_stream(STREAM, ValueType::UInteger64).unwrap();
     }
 
     let (timestamps, values) = read_from_csv("../data/voltage_dataset.csv");
 
-    let mut inserter = conn.prepare_insert(STREAM);
+    let mut inserter = conn.prepare_insert(STREAM).unwrap();
 
     for i in 0..timestamps.len() {
         inserter

--- a/tachyon_core/src/error.rs
+++ b/tachyon_core/src/error.rs
@@ -1,4 +1,4 @@
-use crate::Timestamp;
+use crate::{Timestamp, ValueType};
 use promql_parser::label::Matchers;
 use std::{error::Error, io, path::PathBuf, time::SystemTimeError};
 use thiserror::Error;
@@ -17,6 +17,8 @@ pub enum TachyonErr {
     QueryErr(#[from] QueryErr),
     #[error(transparent)]
     WriterErr(#[from] WriterErr),
+    #[error(transparent)]
+    InserterErr(#[from] InserterErr),
 }
 
 #[derive(Error, Debug)]
@@ -52,8 +54,22 @@ pub enum ConnectionErr {
     DatabaseCreationErr { db_dir: PathBuf },
     #[error("Failed to create stream: {stream}.")]
     StreamCreationErr { stream: String },
+    #[error("Failed to create stream because it already exists: {stream}")]
+    ExistingStreamErr { stream: String },
+    #[error("Failed to insert into stream: {stream}")]
+    StreamInsertErr { stream: String },
+    #[error("Failed to {op} on non-existent stream: {stream}.")]
+    StreamNoExistErr { op: String, stream: String },
     #[error("Failed to get all streams.")]
     GetStreamsErr,
+    #[error("Failed to parse stream {stream} as a vector selector.")]
+    StreamParseErr { stream: String },
+}
+
+#[derive(Error, Debug)]
+pub enum InserterErr {
+    #[error("Can't insert type {this_type} into a stream of type {stream_type}.")]
+    TypeErr { this_type: ValueType, stream_type: ValueType }
 }
 
 #[derive(Error, Debug)]

--- a/tachyon_core/src/error.rs
+++ b/tachyon_core/src/error.rs
@@ -69,7 +69,10 @@ pub enum ConnectionErr {
 #[derive(Error, Debug)]
 pub enum InserterErr {
     #[error("Can't insert type {this_type} into a stream of type {stream_type}.")]
-    TypeErr { this_type: ValueType, stream_type: ValueType }
+    TypeErr {
+        this_type: ValueType,
+        stream_type: ValueType,
+    },
 }
 
 #[derive(Error, Debug)]

--- a/tachyon_core/src/error.rs
+++ b/tachyon_core/src/error.rs
@@ -55,11 +55,11 @@ pub enum ConnectionErr {
     #[error("Failed to create stream: {stream}.")]
     StreamCreationErr { stream: String },
     #[error("Failed to create stream because it already exists: {stream}")]
-    ExistingStreamErr { stream: String },
+    StreamExistsErr { stream: String },
     #[error("Failed to insert into stream: {stream}")]
     StreamInsertErr { stream: String },
     #[error("Failed to {op} on non-existent stream: {stream}.")]
-    StreamNoExistErr { op: String, stream: String },
+    SteamNotFoundErr { op: String, stream: String },
     #[error("Failed to get all streams.")]
     GetStreamsErr,
     #[error("Failed to parse stream {stream} as a vector selector.")]
@@ -69,7 +69,7 @@ pub enum ConnectionErr {
 #[derive(Error, Debug)]
 pub enum InserterErr {
     #[error("Can't insert type {this_type} into a stream of type {stream_type}.")]
-    TypeErr {
+    TypeMismatchErr {
         this_type: ValueType,
         stream_type: ValueType,
     },

--- a/tachyon_core/src/ffi.rs
+++ b/tachyon_core/src/ffi.rs
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn tachyon_stream_delete(connection: *mut Connection, stre
     (*connection).delete_stream(stream);
 }
 
-/// SAFETY: On success (code 0), this returns an `int` (1 if stream exists, 0 otherwise) in the `out` parameter. Otherwise, it returns an error.
+/// SAFETY: On success (code 0), this returns an `int *` (1 if stream exists, 0 otherwise) in the `out` parameter. Otherwise, it returns an error.
 /// The caller is responsible for freeing the returned pointer in `out`.
 /// Success data can be freed by calling free on the returned `int *`.
 /// Error data can be freed by using the function `tachyon_error_free`.

--- a/tachyon_core/src/ffi.rs
+++ b/tachyon_core/src/ffi.rs
@@ -5,13 +5,14 @@ use crate::{
 use std::ffi::{c_char, c_void, CStr};
 
 const FIRST_ERROR_CODE: u8 = 1;
-const LAST_ERROR_CODE: u8 = 4;
+const LAST_ERROR_CODE: u8 = 5;
 
 fn get_error_code(err: &TachyonErr) -> u8 {
     match err {
         TachyonErr::MiscErr { .. } => FIRST_ERROR_CODE,
         TachyonErr::ConnectionErr(_) => 2,
         TachyonErr::QueryErr(_) => 3,
+        TachyonErr::InserterErr(_) => 4,
         TachyonErr::WriterErr(_) => LAST_ERROR_CODE,
     }
 }
@@ -113,9 +114,21 @@ pub unsafe extern "C" fn tachyon_stream_delete(connection: *mut Connection, stre
 pub unsafe extern "C" fn tachyon_stream_check_exists(
     connection: *const Connection,
     stream: *const c_char,
-) -> bool {
+    out: *mut *mut c_void,
+) -> u8 {
     let stream = CStr::from_ptr(stream).to_str().unwrap();
-    (*connection).check_stream_exists(stream)
+    
+    match (*connection).check_stream_exists(stream) {
+        Ok(exists) => {
+            *out = Box::into_raw(Box::new(exists)) as *mut c_void;
+            0u8
+        },
+        Err(tachyon_err) => {
+            let return_value = get_error_code(&tachyon_err);
+            *out = Box::into_raw(Box::new(tachyon_err)) as *mut c_void;
+            return_value
+        }
+    }
 }
 
 /// SAFETY: The caller is responsible for freeing the returned pointer by using the function `tachyon_inserter_close`.
@@ -123,10 +136,22 @@ pub unsafe extern "C" fn tachyon_stream_check_exists(
 pub unsafe extern "C" fn tachyon_inserter_create(
     connection: *mut Connection,
     stream: *const c_char,
-) -> *mut Inserter {
+    out: *mut *mut c_void,
+) -> u8 {
     let stream = CStr::from_ptr(stream).to_str().unwrap();
-    let inserter = (*connection).prepare_insert(stream);
-    Box::into_raw(Box::new(inserter))
+    
+    match (*connection).prepare_insert(stream) {
+        Ok(inserter) => {
+            *out = Box::into_raw(Box::new(inserter))as *mut c_void;
+            0u8
+        },
+        Err(tachyon_err) => {
+            let return_value = get_error_code(&tachyon_err);
+            *out = Box::into_raw(Box::new(tachyon_err)) as *mut c_void;
+            return_value
+        }
+    }
+    
 }
 
 #[no_mangle]

--- a/tachyon_core/src/ffi.rs
+++ b/tachyon_core/src/ffi.rs
@@ -117,12 +117,12 @@ pub unsafe extern "C" fn tachyon_stream_check_exists(
     out: *mut *mut c_void,
 ) -> u8 {
     let stream = CStr::from_ptr(stream).to_str().unwrap();
-    
+
     match (*connection).check_stream_exists(stream) {
         Ok(exists) => {
             *out = Box::into_raw(Box::new(exists)) as *mut c_void;
             0u8
-        },
+        }
         Err(tachyon_err) => {
             let return_value = get_error_code(&tachyon_err);
             *out = Box::into_raw(Box::new(tachyon_err)) as *mut c_void;
@@ -139,19 +139,18 @@ pub unsafe extern "C" fn tachyon_inserter_create(
     out: *mut *mut c_void,
 ) -> u8 {
     let stream = CStr::from_ptr(stream).to_str().unwrap();
-    
+
     match (*connection).prepare_insert(stream) {
         Ok(inserter) => {
-            *out = Box::into_raw(Box::new(inserter))as *mut c_void;
+            *out = Box::into_raw(Box::new(inserter)) as *mut c_void;
             0u8
-        },
+        }
         Err(tachyon_err) => {
             let return_value = get_error_code(&tachyon_err);
             *out = Box::into_raw(Box::new(tachyon_err)) as *mut c_void;
             return_value
         }
     }
-    
 }
 
 #[no_mangle]

--- a/tachyon_core/src/ffi.rs
+++ b/tachyon_core/src/ffi.rs
@@ -2,6 +2,7 @@ use crate::{
     error::{print_error, TachyonErr},
     Connection, Inserter, Query, ReturnType, Timestamp, Value, ValueType, Vector,
 };
+use core::ffi;
 use std::ffi::{c_char, c_void, CStr};
 
 const FIRST_ERROR_CODE: u8 = 1;
@@ -110,6 +111,10 @@ pub unsafe extern "C" fn tachyon_stream_delete(connection: *mut Connection, stre
     (*connection).delete_stream(stream);
 }
 
+/// SAFETY: On success (code 0), this returns an `int` (1 if stream exists, 0 otherwise) in the `out` parameter. Otherwise, it returns an error.
+/// The caller is responsible for freeing the returned pointer in `out`.
+/// Success data can be freed by calling free on the returned `int *`.
+/// Error data can be freed by using the function `tachyon_error_free`.
 #[no_mangle]
 pub unsafe extern "C" fn tachyon_stream_check_exists(
     connection: *const Connection,
@@ -120,6 +125,7 @@ pub unsafe extern "C" fn tachyon_stream_check_exists(
 
     match (*connection).check_stream_exists(stream) {
         Ok(exists) => {
+            let exists: ffi::c_int = if exists { 1 } else { 0 };
             *out = Box::into_raw(Box::new(exists)) as *mut c_void;
             0u8
         }
@@ -131,7 +137,10 @@ pub unsafe extern "C" fn tachyon_stream_check_exists(
     }
 }
 
-/// SAFETY: The caller is responsible for freeing the returned pointer by using the function `tachyon_inserter_close`.
+/// SAFETY: On success (code 0), this returns an `Inserter *` in the `out` parameter. Otherwise, it returns an error.
+/// The caller is responsible for freeing the returned pointer in `out`.
+/// Success data can be freed by using the function `tachyon_inserter_close`.
+/// Error data can be freed by using the function `tachyon_error_free`.
 #[no_mangle]
 pub unsafe extern "C" fn tachyon_inserter_create(
     connection: *mut Connection,

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -408,16 +408,23 @@ impl Connection {
         })
     }
 
-    fn parse_stream(&self, stream: impl AsRef<str>) -> parser::VectorSelector {
+    fn parse_stream_for_insert(
+        &self,
+        stream: impl AsRef<str>,
+    ) -> Result<parser::VectorSelector, ConnectionErr> {
         let Ok(parser::Expr::VectorSelector(selector)) = parser::parse(stream.as_ref()) else {
-            panic!("Expected a vector selector!");
+            return Err(ConnectionErr::StreamParseErr {
+                stream: stream.as_ref().to_string(),
+            });
         };
 
         if selector.at.is_some() || selector.offset.is_some() {
-            panic!("Cannot include at / offset for insert query!");
+            return Err(ConnectionErr::StreamParseErr {
+                stream: stream.as_ref().to_string(),
+            });
         }
 
-        selector
+        Ok(selector)
     }
 
     fn get_stream_ids_for_selector(&self, selector: &parser::VectorSelector) -> HashSet<Uuid> {
@@ -431,10 +438,14 @@ impl Connection {
         stream: impl AsRef<str>,
         value_type: ValueType,
     ) -> Result<(), TachyonErr> {
-        let selector = self.parse_stream(&stream);
+        let selector = self.parse_stream_for_insert(&stream)?;
 
         if !self.get_stream_ids_for_selector(&selector).is_empty() {
-            panic!("Attempting to create a stream that already exists!");
+            return Err(TachyonErr::ConnectionErr(
+                ConnectionErr::ExistingStreamErr {
+                    stream: stream.as_ref().to_string(),
+                },
+            ));
         }
 
         let stream_id = self
@@ -459,10 +470,10 @@ impl Connection {
         todo!("Not deleting stream {:?}", stream.as_ref());
     }
 
-    pub fn check_stream_exists(&self, stream: impl AsRef<str>) -> bool {
-        !self
-            .get_stream_ids_for_selector(&self.parse_stream(stream))
-            .is_empty()
+    pub fn check_stream_exists(&self, stream: impl AsRef<str>) -> Result<bool, TachyonErr> {
+        Ok(!self
+            .get_stream_ids_for_selector(&self.parse_stream_for_insert(stream)?)
+            .is_empty())
     }
 
     pub fn get_all_streams(&self) -> Result<Vec<StreamSummaryType>, TachyonErr> {
@@ -472,16 +483,24 @@ impl Connection {
             .map_err(|_| TachyonErr::ConnectionErr(ConnectionErr::GetStreamsErr))
     }
 
-    pub fn prepare_insert(&mut self, stream: impl AsRef<str>) -> Inserter {
-        let stream_ids = self.get_stream_ids_for_selector(&self.parse_stream(stream.as_ref()));
+    pub fn prepare_insert(&mut self, stream: impl AsRef<str>) -> Result<Inserter, TachyonErr> {
+        let stream_ids =
+            self.get_stream_ids_for_selector(&self.parse_stream_for_insert(stream.as_ref())?);
 
-        if stream_ids.len() != 1 {
-            panic!("Invalid number of streams found in the database!");
+        if stream_ids.len() == 0 {
+            return Err(TachyonErr::ConnectionErr(ConnectionErr::StreamNoExistErr {
+                op: "insert".to_string(),
+                stream: stream.as_ref().to_string(),
+            }));
+        } else if stream_ids.len() > 1 {
+            return Err(TachyonErr::ConnectionErr(ConnectionErr::StreamInsertErr {
+                stream: stream.as_ref().to_string(),
+            }));
         }
 
         let stream_id = stream_ids.into_iter().next().unwrap();
 
-        Inserter {
+        Ok(Inserter {
             value_type: self
                 .indexer
                 .borrow()
@@ -489,7 +508,7 @@ impl Connection {
                 .unwrap(),
             stream_id,
             writer: self.writer.clone(),
-        }
+        })
     }
 
     pub fn prepare_query(
@@ -525,7 +544,12 @@ macro_rules! create_inserter_insert {
             value: $type,
         ) -> Result<(), crate::error::TachyonErr> {
             if self.value_type != $value_type {
-                panic!("Invalid value type on insert!");
+                return Err(crate::error::TachyonErr::InserterErr(
+                    crate::error::InserterErr::TypeErr {
+                        this_type: $value_type,
+                        stream_type: self.value_type,
+                    },
+                ));
             }
 
             self.insert(
@@ -604,11 +628,11 @@ mod tests {
         stream: impl AsRef<str>,
         value_type: ValueType,
     ) -> Inserter {
-        if !conn.check_stream_exists(stream.as_ref()) {
+        if !conn.check_stream_exists(stream.as_ref()).unwrap() {
             conn.create_stream(stream.as_ref(), value_type).unwrap();
         }
 
-        conn.prepare_insert(stream.as_ref())
+        conn.prepare_insert(stream.as_ref()).unwrap()
     }
 
     fn vector_test_helper(
@@ -1848,7 +1872,7 @@ mod tests {
 
         {
             let mut conn = Connection::new(&root_dir).unwrap();
-            let mut inserter = conn.prepare_insert(r#"http_requests_total"#);
+            let mut inserter = conn.prepare_insert(r#"http_requests_total"#).unwrap();
 
             for i in mid..end {
                 inserter.insert_float64(i, i as f64).unwrap();

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -441,11 +441,9 @@ impl Connection {
         let selector = self.parse_stream_for_insert(&stream)?;
 
         if !self.get_stream_ids_for_selector(&selector).is_empty() {
-            return Err(TachyonErr::ConnectionErr(
-                ConnectionErr::StreamExistsErr {
-                    stream: stream.as_ref().to_string(),
-                },
-            ));
+            return Err(TachyonErr::ConnectionErr(ConnectionErr::StreamExistsErr {
+                stream: stream.as_ref().to_string(),
+            }));
         }
 
         let stream_id = self

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -442,7 +442,7 @@ impl Connection {
 
         if !self.get_stream_ids_for_selector(&selector).is_empty() {
             return Err(TachyonErr::ConnectionErr(
-                ConnectionErr::ExistingStreamErr {
+                ConnectionErr::StreamExistsErr {
                     stream: stream.as_ref().to_string(),
                 },
             ));
@@ -488,7 +488,7 @@ impl Connection {
             self.get_stream_ids_for_selector(&self.parse_stream_for_insert(stream.as_ref())?);
 
         if stream_ids.is_empty() {
-            return Err(TachyonErr::ConnectionErr(ConnectionErr::StreamNoExistErr {
+            return Err(TachyonErr::ConnectionErr(ConnectionErr::SteamNotFoundErr {
                 op: "insert".to_string(),
                 stream: stream.as_ref().to_string(),
             }));
@@ -545,7 +545,7 @@ macro_rules! create_inserter_insert {
         ) -> Result<(), crate::error::TachyonErr> {
             if self.value_type != $value_type {
                 return Err(crate::error::TachyonErr::InserterErr(
-                    crate::error::InserterErr::TypeErr {
+                    crate::error::InserterErr::TypeMismatchErr {
                         this_type: $value_type,
                         stream_type: self.value_type,
                     },

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -487,7 +487,7 @@ impl Connection {
         let stream_ids =
             self.get_stream_ids_for_selector(&self.parse_stream_for_insert(stream.as_ref())?);
 
-        if stream_ids.len() == 0 {
+        if stream_ids.is_empty() {
             return Err(TachyonErr::ConnectionErr(ConnectionErr::StreamNoExistErr {
                 op: "insert".to_string(),
                 stream: stream.as_ref().to_string(),


### PR DESCRIPTION
Remove the panics in `lib.rs`. Fixes the bug where we panic when trying to create an existing stream or write to a non-existing stream. New behaviour is pictured below.

<img width="531" alt="Screenshot 2025-03-23 at 5 25 10 PM" src="https://github.com/user-attachments/assets/96b233b6-91b1-4979-beaa-ae5779499ffd" />
