### PR TITLE
add file locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2381,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2749,7 @@ dependencies = [
  "promql-parser",
  "rusqlite",
  "rustc-hash 2.1.0",
+ "rustix 1.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.11",

--- a/examples/concurrency_test/Cargo.toml
+++ b/examples/concurrency_test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "concurrency_test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tachyon_core = { path = "../../tachyon_core" }
+rustix = { version = "0.38.4", features = ["fs"] }
+rand = "0.8"
+chrono = "0.4"

--- a/examples/concurrency_test/src/main.rs
+++ b/examples/concurrency_test/src/main.rs
@@ -87,7 +87,7 @@ fn run_parent() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = Connection::new(TEST_DIR)?;
 
     // Create a stream for timestamp and value
-    if !conn.check_stream_exists(STREAM_NAME) {
+    if !conn.check_stream_exists(STREAM_NAME).unwrap() {
         conn.create_stream(STREAM_NAME, ValueType::UInteger64)?;
         log_with_timestamp(
             &mut output_file,
@@ -101,7 +101,7 @@ fn run_parent() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Prepare an inserter to add data to the stream
-    let mut inserter = conn.prepare_insert(STREAM_NAME);
+    let mut inserter = conn.prepare_insert(STREAM_NAME).unwrap();
 
     let mut i = 1;
     let mut accum = 0;
@@ -173,7 +173,7 @@ fn run_child() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = Connection::new(TEST_DIR)?;
 
     // Verify the stream exists
-    if !conn.check_stream_exists(STREAM_NAME) {
+    if !conn.check_stream_exists(STREAM_NAME).unwrap() {
         log_with_timestamp(
             &mut output_file,
             &format!("Stream {} does not exist", STREAM_NAME),

--- a/examples/concurrency_test/src/main.rs
+++ b/examples/concurrency_test/src/main.rs
@@ -1,0 +1,261 @@
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Local, Utc};
+use rand::Rng;
+use tachyon_core::ReturnType;
+use tachyon_core::{Connection, ValueType};
+
+const TEST_DIR: &str = "concurrency_test_data";
+const STREAM_NAME: &str = "test_stream";
+const PARENT_ROWS: usize = 100;
+const CHILD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+const PARENT_OUTPUT_FILE: &str = "parent_output.txt";
+const CHILD_OUTPUT_FILE: &str = "child_output.txt";
+
+// Helper function to log with timestamp to a file
+fn log_with_timestamp(file: &mut File, message: &str) -> Result<(), std::io::Error> {
+    writeln!(
+        file,
+        "[{}] {}",
+        Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+        message
+    )
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    // Create test directory if it doesn't exist
+    if !Path::new(TEST_DIR).exists() {
+        fs::create_dir(TEST_DIR).expect("Failed to create test directory");
+    }
+
+    if args.len() <= 1 {
+        // Parent process initialization - print to console and to file
+        println!("Parent process starting - will create stream and spawn child");
+        // Create parent output file for the rest of the logging
+        File::create(PARENT_OUTPUT_FILE)
+            .expect("Failed to create parent output file")
+            .write_all(
+                format!(
+                    "[{}] Parent process starting - will create stream and spawn child\n",
+                    Local::now().format("%Y-%m-%d %H:%M:%S%.3f")
+                )
+                .as_bytes(),
+            )
+            .expect("Failed to write to parent output file");
+        run_parent().expect("Parent process failed");
+    } else if args[1] == "child" {
+        // Child process initialization - print to console and to file
+        println!("Child process starting - will read from stream");
+        // Create child output file for the rest of the logging
+        File::create(CHILD_OUTPUT_FILE)
+            .expect("Failed to create child output file")
+            .write_all(
+                format!(
+                    "[{}] Child process starting - will read from stream\n",
+                    Local::now().format("%Y-%m-%d %H:%M:%S%.3f")
+                )
+                .as_bytes(),
+            )
+            .expect("Failed to write to child output file");
+        run_child().expect("Child process failed");
+    }
+}
+
+fn run_parent() -> Result<(), Box<dyn std::error::Error>> {
+    // Open the parent output file for appending
+    let mut output_file = fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(PARENT_OUTPUT_FILE)?;
+
+    writeln!(
+        output_file,
+        "Parent process started at {:?}",
+        Instant::now()
+    )?;
+
+    // Create a connection to the database
+    let mut conn = Connection::new(TEST_DIR)?;
+
+    // Create a stream for timestamp and value
+    if !conn.check_stream_exists(STREAM_NAME) {
+        conn.create_stream(STREAM_NAME, ValueType::UInteger64)?;
+        log_with_timestamp(
+            &mut output_file,
+            &format!("Parent: Created stream {}", STREAM_NAME),
+        )?;
+    } else {
+        log_with_timestamp(
+            &mut output_file,
+            &format!("Parent: Using existing stream {}", STREAM_NAME),
+        )?;
+    }
+
+    // Prepare an inserter to add data to the stream
+    let mut inserter = conn.prepare_insert(STREAM_NAME);
+
+    let mut i = 1;
+    let mut accum = 0;
+
+    let start_time = Instant::now();
+
+    let mut child = Command::new(env::current_exe()?).arg("child").spawn()?;
+
+    loop {
+        // Use timestamp_nanos_opt instead of deprecated timestamp_nanos
+        let timestamp = i;
+        accum += i;
+        let value = accum;
+        assert_eq!(value, i * (i + 1) / 2);
+
+        inserter.insert_uinteger64(timestamp, value)?;
+
+        if i % 10 == 0 {
+            log_with_timestamp(
+                &mut output_file,
+                &format!("Parent: Inserted 10 rows {}. Last value: {}", i, value),
+            )?;
+        }
+
+        // Small delay to avoid timestamp collisions
+        // sleep(Duration::from_millis(1));
+        i += 1;
+
+        if start_time.elapsed() > Duration::from_secs(240) {
+            break;
+        }
+    }
+
+    inserter.flush()?;
+    child.wait()?;
+
+    log_with_timestamp(
+        &mut output_file,
+        &format!("Parent: Done at {:?}!", Instant::now()),
+    )?;
+    // Flush and close output file
+    output_file.flush()?;
+    Ok(())
+}
+
+fn run_child() -> Result<(), Box<dyn std::error::Error>> {
+    // Open the child output file for appending
+    let mut output_file = fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(CHILD_OUTPUT_FILE)?;
+
+    writeln!(output_file, "Child process started at {:?}", Instant::now())?;
+
+    // Give the parent process a moment to create the database and stream
+    let start_time = Instant::now();
+    while !Path::new(TEST_DIR).exists() || start_time.elapsed() < Duration::from_millis(200) {
+        if start_time.elapsed() > CHILD_WAIT_TIMEOUT {
+            log_with_timestamp(
+                &mut output_file,
+                "Timed out waiting for database to be created",
+            )?;
+            return Err("Timed out waiting for database to be created".into());
+        }
+        sleep(Duration::from_millis(100));
+    }
+
+    // Connect to the database
+    let mut conn = Connection::new(TEST_DIR)?;
+
+    // Verify the stream exists
+    if !conn.check_stream_exists(STREAM_NAME) {
+        log_with_timestamp(
+            &mut output_file,
+            &format!("Stream {} does not exist", STREAM_NAME),
+        )?;
+        return Err(format!("Stream {} does not exist", STREAM_NAME).into());
+    }
+
+    log_with_timestamp(
+        &mut output_file,
+        &format!(
+            "Child: Successfully connected to database and found stream {}",
+            STREAM_NAME
+        ),
+    )?;
+
+    // Read from the stream using a query
+    let mut total_read = 0;
+
+    // Continue checking for new rows for a while
+    let start_time = Instant::now();
+    let mut values = Vec::new();
+
+    loop {
+        // Query all values from the stream with a timestamp range
+        // Using the PromQL format that Tachyon expects
+        let query_str = STREAM_NAME.to_string(); // Simple metric name without filters
+        let mut query = conn.prepare_query(
+            &query_str,
+            Some(0),               // Start timestamp from 0
+            Some(i64::MAX as u64), // End timestamp to maximum possible value
+        )?;
+
+        // Count how many values we can read
+        let mut count = 0;
+        while let Some(value) = query.next_vector() {
+            count += 1;
+            if count % 1000 == 0 {
+                log_with_timestamp(
+                    &mut output_file,
+                    &format!("Still reading... {} records so far", count),
+                )?;
+            }
+            if count > total_read {
+                values.push(value.value.get_uinteger64());
+                let length = values.len() as u64;
+
+                assert_eq!(*values.last().unwrap(), length * (length + 1) / 2);
+            }
+        }
+
+        if count > total_read {
+            log_with_timestamp(
+                &mut output_file,
+                &format!(
+                    "Child: Found {} new rows, total now {}",
+                    count - total_read,
+                    count
+                ),
+            )?;
+
+            // Print the last few values we read
+            let num_to_show = std::cmp::min(5, values.len());
+            for (_i, value) in values.iter().rev().take(num_to_show).enumerate() {
+                log_with_timestamp(&mut output_file, &format!("Child: Read value {}", value))?;
+            }
+
+            total_read = count;
+        }
+
+        // sleep(Duration::from_millis(100));
+
+        if start_time.elapsed() > Duration::from_secs(240) {
+            break;
+        }
+    }
+
+    log_with_timestamp(
+        &mut output_file,
+        &format!("Child: Done at {:?}!", Instant::now()),
+    )?;
+    // Flush and close output file
+    output_file.flush()?;
+
+    Ok(())
+}

--- a/tachyon_core/Cargo.toml
+++ b/tachyon_core/Cargo.toml
@@ -51,6 +51,7 @@ dhat = { version = "0.3.3", optional = true }
 promql-parser = { path = "../tachyondb-promql-parser" }
 rusqlite = { version = "0.32.1", features = ["serde_json", "bundled", "uuid"] }
 rustc-hash = "2.1.0"
+rustix = { version = "1.0.3", features = ["fs"] }
 serde = "1.0.217"
 serde_json = "1.0.137"
 thiserror = "2.0.11"

--- a/tachyon_core/benches/db_benchmark_framework.rs
+++ b/tachyon_core/benches/db_benchmark_framework.rs
@@ -581,13 +581,13 @@ fn timescaledb_read_benchmark(c: &mut Criterion) {
 criterion_group!(
     name = insert_benches;
     config = get_criterion_config::<20>();
-    targets = tachyon_insert_benchmark, sqlite_insert_benchmark // , timescaledb_insert_benchmark
+    targets = tachyon_insert_benchmark, sqlite_insert_benchmark , timescaledb_insert_benchmark
 );
 
 criterion_group!(
     name = read_benches;
     config = get_criterion_config::<100>();
-    targets = tachyon_read_benchmark, sqlite_read_benchmark // , timescaledb_read_benchmark
+    targets = tachyon_read_benchmark, sqlite_read_benchmark , timescaledb_read_benchmark
 );
 
 criterion_main!(read_benches, insert_benches);

--- a/tachyon_core/benches/db_benchmark_framework.rs
+++ b/tachyon_core/benches/db_benchmark_framework.rs
@@ -581,13 +581,13 @@ fn timescaledb_read_benchmark(c: &mut Criterion) {
 criterion_group!(
     name = insert_benches;
     config = get_criterion_config::<20>();
-    targets = tachyon_insert_benchmark, sqlite_insert_benchmark, timescaledb_insert_benchmark
+    targets = tachyon_insert_benchmark, sqlite_insert_benchmark // , timescaledb_insert_benchmark
 );
 
 criterion_group!(
     name = read_benches;
     config = get_criterion_config::<100>();
-    targets = tachyon_read_benchmark, sqlite_read_benchmark, timescaledb_read_benchmark
+    targets = tachyon_read_benchmark, sqlite_read_benchmark // , timescaledb_read_benchmark
 );
 
 criterion_main!(read_benches, insert_benches);

--- a/tachyon_core/benches/db_benchmark_framework.rs
+++ b/tachyon_core/benches/db_benchmark_framework.rs
@@ -581,13 +581,13 @@ fn timescaledb_read_benchmark(c: &mut Criterion) {
 criterion_group!(
     name = insert_benches;
     config = get_criterion_config::<20>();
-    targets = tachyon_insert_benchmark, sqlite_insert_benchmark , timescaledb_insert_benchmark
+    targets = tachyon_insert_benchmark, sqlite_insert_benchmark, timescaledb_insert_benchmark
 );
 
 criterion_group!(
     name = read_benches;
     config = get_criterion_config::<100>();
-    targets = tachyon_read_benchmark, sqlite_read_benchmark , timescaledb_read_benchmark
+    targets = tachyon_read_benchmark, sqlite_read_benchmark, timescaledb_read_benchmark
 );
 
 criterion_main!(read_benches, insert_benches);

--- a/tachyon_core/src/storage/file.rs
+++ b/tachyon_core/src/storage/file.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -17,6 +18,70 @@ const MAGIC_SIZE: usize = 4;
 const MAGIC: [u8; MAGIC_SIZE] = [b'T', b'a', b'c', b'h'];
 
 const HEADER_SIZE: usize = 71;
+
+pub struct FileLockGuard {
+    fd: RawFd,
+    released: bool,
+}
+
+impl FileLockGuard {
+    pub fn new_shared(fd: &File) -> Result<Self, io::Error> {
+        rustix::fs::flock(fd.as_fd(), rustix::fs::FlockOperation::LockShared)?;
+        Ok(Self {
+            fd: fd.as_raw_fd(),
+            released: false,
+        })
+    }
+
+    pub fn new_exclusive(fd: &File) -> Result<Self, io::Error> {
+        rustix::fs::flock(fd.as_fd(), rustix::fs::FlockOperation::LockExclusive)?;
+        Ok(Self {
+            fd: fd.as_raw_fd(),
+            released: false,
+        })
+    }
+
+    pub fn non_blocking_new_shared(fd: &File) -> Result<Self, io::Error> {
+        rustix::fs::flock(
+            fd.as_fd(),
+            rustix::fs::FlockOperation::NonBlockingLockShared,
+        )?;
+        Ok(Self {
+            fd: fd.as_raw_fd(),
+            released: false,
+        })
+    }
+
+    pub fn non_blocking_new_exclusive(fd: &File) -> Result<Self, io::Error> {
+        rustix::fs::flock(
+            fd.as_fd(),
+            rustix::fs::FlockOperation::NonBlockingLockExclusive,
+        )?;
+        Ok(Self {
+            fd: fd.as_raw_fd(),
+            released: false,
+        })
+    }
+
+    pub fn release(&mut self) -> Result<(), io::Error> {
+        if self.released {
+            return Ok(());
+        }
+        rustix::fs::flock(
+            unsafe { BorrowedFd::borrow_raw(self.fd) },
+            rustix::fs::FlockOperation::Unlock,
+        )?;
+        self.released = true;
+
+        Ok(())
+    }
+}
+
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        let _ = self.release();
+    }
+}
 
 #[derive(Clone)]
 pub struct Header {
@@ -234,6 +299,8 @@ struct CursorImpl {
     scan_hint: ScanHint,
 
     is_done: bool,
+
+    file_lock: FileLockGuard,
 }
 
 impl CursorImpl {
@@ -253,6 +320,7 @@ impl CursorImpl {
         let file_id = page_cache_ref.register_or_get_file_id(&file_paths[0]);
         let header = Header::parse(file_id, &mut page_cache_ref);
 
+        let file_lock = FileLockGuard::new_shared(page_cache_ref.get_file(file_id))?;
         drop(page_cache_ref);
 
         let decomp_engine = IntDecompressor::new(
@@ -278,6 +346,7 @@ impl CursorImpl {
             scan_hint,
 
             is_done: false,
+            file_lock,
         };
 
         cursor.use_query_hint_for_value(cursor.value);
@@ -331,6 +400,10 @@ impl CursorImpl {
         self.file_index += 1;
 
         if self.file_index == self.file_paths.len() {
+            // flush all pages from the last file
+            self.page_cache
+                .borrow_mut()
+                .flush_pages_for_file(self.file_id);
             return None;
         }
         self.file_id = self
@@ -355,6 +428,9 @@ impl CursorImpl {
             &self.header,
         );
 
+        self.file_lock =
+            FileLockGuard::new_shared(self.page_cache.borrow_mut().get_file(self.file_id)).unwrap();
+
         // Use the query hint if applicable on the next file
         if self.scan_hint != ScanHint::None
             && self.start <= self.header.min_timestamp
@@ -378,6 +454,7 @@ impl CursorImpl {
         if self.values_read == self.header.count as u64 {
             if self.load_next_file().is_none() {
                 self.is_done = true;
+                self.file_lock.release().unwrap();
             }
             return Some(to_return);
         }
@@ -388,6 +465,7 @@ impl CursorImpl {
         self.use_query_hint_for_value(self.value);
 
         if self.current_timestamp > self.end {
+            self.file_lock.release().unwrap();
             self.is_done = true;
         }
         self.values_read += 1;
@@ -700,11 +778,13 @@ impl PartiallyPersistentDataFileWriter {
 
 impl Write for PartiallyPersistentDataFileWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let _guard = FileLockGuard::new_exclusive(&self.file)?;
         let header_bytes = self.header.borrow().as_bytes();
         self.file.seek(SeekFrom::Start(0))?;
         self.file.write_all(&header_bytes)?;
         self.file.seek(SeekFrom::End(0))?;
-        self.file.write(buf)
+        let written = self.file.write(buf)?;
+        Ok(written)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/tachyon_core/src/storage/file.rs
+++ b/tachyon_core/src/storage/file.rs
@@ -19,6 +19,15 @@ const MAGIC: [u8; MAGIC_SIZE] = [b'T', b'a', b'c', b'h'];
 
 const HEADER_SIZE: usize = 71;
 
+/*
+This structure is responsible for handling file-level locks.
+Currently, only Unix-based systems are supported. [shared] locks
+correspond to readers and [exclusive] locks correspond to writers.
+
+There can only be one process with an exclusive lock, but multiple
+processes can have shared locks. However, a shared lock and an
+exclusive lock cannot be held at the same time.
+*/
 pub struct FileLockGuard {
     fd: RawFd,
     released: bool,
@@ -400,10 +409,6 @@ impl CursorImpl {
         self.file_index += 1;
 
         if self.file_index == self.file_paths.len() {
-            // flush all pages from the last file
-            self.page_cache
-                .borrow_mut()
-                .flush_pages_for_file(self.file_id);
             return None;
         }
         self.file_id = self
@@ -454,6 +459,16 @@ impl CursorImpl {
         if self.values_read == self.header.count as u64 {
             if self.load_next_file().is_none() {
                 self.is_done = true;
+                // flush all pages from the last file - it's possible
+                // that the last file is not closed so it could be mutated
+                // by another process and so we do not want stale data
+                // TODO: Check if open
+                self.page_cache
+                    .borrow_mut()
+                    .flush_pages_for_file(self.file_id);
+
+                // release early just in case cursor isn't dropped right away
+                // to allow other processes to continue
                 self.file_lock.release().unwrap();
             }
             return Some(to_return);
@@ -465,6 +480,13 @@ impl CursorImpl {
         self.use_query_hint_for_value(self.value);
 
         if self.current_timestamp > self.end {
+            // flush all pages from the last file
+            self.page_cache
+                .borrow_mut()
+                .flush_pages_for_file(self.file_id);
+
+            // release early just in case cursor isn't dropped right away
+            // to allow other processes to continue
             self.file_lock.release().unwrap();
             self.is_done = true;
         }
@@ -784,6 +806,8 @@ impl Write for PartiallyPersistentDataFileWriter {
         self.file.write_all(&header_bytes)?;
         self.file.seek(SeekFrom::End(0))?;
         let written = self.file.write(buf)?;
+
+        // lock dropped via RAII
         Ok(written)
     }
 

--- a/tachyon_core/src/storage/page_cache.rs
+++ b/tachyon_core/src/storage/page_cache.rs
@@ -167,6 +167,7 @@ impl PageCache {
             e.insert(File::open(path).unwrap());
         }
 
+        // SAFETY: we ensure that the file is inserted above, so this is guaranteed to be Some
         self.open_files.get(&file_id).unwrap()
     }
 

--- a/tachyon_core/src/storage/page_cache.rs
+++ b/tachyon_core/src/storage/page_cache.rs
@@ -145,6 +145,31 @@ impl PageCache {
         self.cur_file_id - 1
     }
 
+    // Removes all pages from the file
+    pub fn flush_pages_for_file(&mut self, file_id: FileId) {
+        // 1. flush all pages from the page cache for file ID
+        // TODO: Check if this needs to be optimized
+        for frame in &mut self.frames {
+            if let Frame::Page(page) = frame {
+                if page.file_id == file_id {
+                    self.mapping
+                        .remove(&(((page.file_id as u64) << 32) | (page.page_id as u64)));
+                    *frame = Frame::Empty;
+                }
+            }
+        }
+    }
+
+    pub fn get_file(&mut self, file_id: FileId) -> &File {
+        // Check that file is open
+        if let std::collections::hash_map::Entry::Vacant(e) = self.open_files.entry(file_id) {
+            let path = self.file_id_to_path.get(&file_id).unwrap();
+            e.insert(File::open(path).unwrap());
+        }
+
+        self.open_files.get(&file_id).unwrap()
+    }
+
     fn load_page(&mut self, file_id: FileId, page_id: PageId) -> FrameId {
         let frame_id;
         // 1st - check that page_id is loaded in memory


### PR DESCRIPTION
There are two types of locks:
1. Shared Locks
2. Exclusive locks

Shared locks are for readers, and exclusive locks are for writers. I also offer non-blocking variants for each type of lock. OS flock is only supported on unix.

My locking strategy is as follows:
- In persistent writer write, which is the only writer called through inserter, we grab exclusive lock on the file before writing. We release immediately after writing chunk & updating header

- For readers, we hold the shared lock for the current file of the cursor. When cursor iterates to next file, we release the previous lock (through RAII) and grab a shared lock on the next file. 

There are is an edge case to cover:
- Given a reader process R, and writer process W: 
1. R grabs shared lock on file. Starts loading pages of file into page cache
2. R releases shared lock
3. W grabs exclusive lock and writes to file and releases exclusive lock
4. R grabs shared lock again, and reads the same file again - the previous pages are still in the page cache. However, this data is stale.

To prevent this case, we flush all pages of the last file of any read to ensure we always read fresh data for mutable files. 

