### PR TITLE
Feature: Delete streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +942,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +989,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "endian-type"
@@ -2515,6 +2547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2747,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "csv",
+ "dialoguer",
  "dir-size",
  "rustyline",
  "tabled",
@@ -3545,6 +3584,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/tachyon_cli/Cargo.toml
+++ b/tachyon_cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
 csv = "1.3.1"
+dialoguer = "0.11.0"
 dir-size = "0.1.1"
 rustyline = "15.0.0"
 tabled = "0.18.0"

--- a/tachyon_cli/src/handlers/commands/mod.rs
+++ b/tachyon_cli/src/handlers/commands/mod.rs
@@ -4,6 +4,7 @@ use clap::{
     builder::{NonEmptyStringValueParser, PossibleValuesParser, TypedValueParser},
     command, Parser,
 };
+use dialoguer::Confirm;
 use tachyon_core::{Connection, ValueType, Vector};
 
 use crate::{
@@ -36,6 +37,10 @@ pub enum TachyonCommand {
         create: bool,
     },
     Create {
+        #[arg(value_parser = NonEmptyStringValueParser::new())]
+        stream: String,
+    },
+    Delete {
         #[arg(value_parser = NonEmptyStringValueParser::new())]
         stream: String,
     },
@@ -104,6 +109,22 @@ pub fn handle_command(
         }
         TachyonCommand::Create { stream } => {
             connection.create_stream(stream, config.value_type)?;
+            Ok(())
+        }
+        TachyonCommand::Delete { stream } => {
+            let stream_names = connection.get_matching_stream_names(&stream)?;
+
+            println!("This will delete the following streams:");
+            for stream_name in stream_names {
+                println!("{}", stream_name);
+            }
+
+            let confirmation = Confirm::new()
+                .with_prompt("Do you want to continue?")
+                .interact();
+            if confirmation.is_ok_and(|x| x) {
+                connection.delete_stream(stream)?;
+            }
             Ok(())
         }
         TachyonCommand::Exit => {

--- a/tachyon_core/src/error.rs
+++ b/tachyon_core/src/error.rs
@@ -55,7 +55,11 @@ pub enum ConnectionErr {
     #[error("Failed to create stream: {stream}.")]
     StreamCreationErr { stream: String },
     #[error("Failed to create stream because it already exists: {stream}")]
-    StreamExistsErr { stream: String },
+    ExistingStreamCreationErr { stream: String },
+    #[error("Failed to delete stream: {stream}.")]
+    StreamDeletionErr { stream: String },
+    #[error("Failed to delete stream because it does not exist: {stream}")]
+    MissingStreamDeletionErr { stream: String },
     #[error("Failed to insert into stream: {stream}")]
     StreamInsertErr { stream: String },
     #[error("Failed to {op} on non-existent stream: {stream}.")]

--- a/tachyon_core/src/ffi.rs
+++ b/tachyon_core/src/ffi.rs
@@ -105,10 +105,14 @@ pub unsafe extern "C" fn tachyon_stream_create(
     }
 }
 
+/// SAFETY: On error (not code 0), this returns an error in the `out` parameter.
+/// The caller is responsible for freeing the returned pointer in `out`.
+/// Error data can be freed by using the function `tachyon_error_free`.
 #[no_mangle]
 pub unsafe extern "C" fn tachyon_stream_delete(
     connection: *mut Connection,
     stream: *const c_char,
+    out: *mut *mut c_void,
 ) -> u8 {
     let stream_res = CStr::from_ptr(stream)
         .to_str()
@@ -119,9 +123,17 @@ pub unsafe extern "C" fn tachyon_stream_delete(
     match stream_res {
         Ok(stream) => match (*connection).delete_stream(stream) {
             Ok(()) => 0u8,
-            Err(tachyon_err) => get_error_code(&tachyon_err),
+            Err(tachyon_err) => {
+                let return_value = get_error_code(&tachyon_err);
+                *out = Box::into_raw(Box::new(tachyon_err)) as *mut c_void;
+                return_value
+            }
         },
-        Err(tachyon_err) => get_error_code(&tachyon_err),
+        Err(tachyon_err) => {
+            let return_value = get_error_code(&tachyon_err);
+            *out = Box::into_raw(Box::new(tachyon_err)) as *mut c_void;
+            return_value
+        }
     }
 }
 

--- a/tachyon_core/src/ffi.rs
+++ b/tachyon_core/src/ffi.rs
@@ -106,9 +106,23 @@ pub unsafe extern "C" fn tachyon_stream_create(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn tachyon_stream_delete(connection: *mut Connection, stream: *const c_char) {
-    let stream = CStr::from_ptr(stream).to_str().unwrap();
-    (*connection).delete_stream(stream);
+pub unsafe extern "C" fn tachyon_stream_delete(
+    connection: *mut Connection,
+    stream: *const c_char,
+) -> u8 {
+    let stream_res = CStr::from_ptr(stream)
+        .to_str()
+        .map_err(|err| TachyonErr::MiscErr {
+            inner: Box::new(err),
+        });
+
+    match stream_res {
+        Ok(stream) => match (*connection).delete_stream(stream) {
+            Ok(()) => 0u8,
+            Err(tachyon_err) => get_error_code(&tachyon_err),
+        },
+        Err(tachyon_err) => get_error_code(&tachyon_err),
+    }
 }
 
 /// SAFETY: On success (code 0), this returns an `int *` (1 if stream exists, 0 otherwise) in the `out` parameter. Otherwise, it returns an error.

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -433,33 +433,6 @@ impl Connection {
             .get_stream_ids(selector.name.as_ref().unwrap(), &selector.matchers)
     }
 
-    pub fn get_matching_stream_names(
-        &self,
-        stream: impl AsRef<str>,
-    ) -> Result<Vec<String>, TachyonErr> {
-        let selector = self.parse_stream_for_insert(&stream)?;
-
-        let stream_ids = self.get_stream_ids_for_selector(&selector);
-        let all_stream_names = self.get_all_stream_names()?;
-
-        let mut stream_names: Vec<String> = Vec::new();
-        for (stream_id, stream_name) in all_stream_names {
-            if stream_ids.contains(&stream_id) {
-                stream_names.push(stream_name);
-            }
-        }
-
-        if stream_names.is_empty() {
-            return Err(TachyonErr::ConnectionErr(
-                ConnectionErr::MissingStreamDeletionErr {
-                    stream: stream.as_ref().to_string(),
-                },
-            ));
-        }
-
-        Ok(stream_names)
-    }
-
     pub fn create_stream(
         &mut self,
         stream: impl AsRef<str>,
@@ -541,6 +514,33 @@ impl Connection {
             .borrow()
             .get_all_stream_names()
             .map_err(|_| TachyonErr::ConnectionErr(ConnectionErr::GetStreamsErr))
+    }
+
+    pub fn get_matching_stream_names(
+        &self,
+        stream: impl AsRef<str>,
+    ) -> Result<Vec<String>, TachyonErr> {
+        let selector = self.parse_stream_for_insert(&stream)?;
+
+        let stream_ids = self.get_stream_ids_for_selector(&selector);
+        let all_stream_names = self.get_all_stream_names()?;
+
+        let mut stream_names: Vec<String> = Vec::new();
+        for (stream_id, stream_name) in all_stream_names {
+            if stream_ids.contains(&stream_id) {
+                stream_names.push(stream_name);
+            }
+        }
+
+        if stream_names.is_empty() {
+            return Err(TachyonErr::ConnectionErr(
+                ConnectionErr::MissingStreamDeletionErr {
+                    stream: stream.as_ref().to_string(),
+                },
+            ));
+        }
+
+        Ok(stream_names)
     }
 
     pub fn prepare_insert(&mut self, stream: impl AsRef<str>) -> Result<Inserter, TachyonErr> {
@@ -677,11 +677,18 @@ pub mod tachyon_benchmarks {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use crate::{
         utils::test::set_up_dirs, Connection, Inserter, Query, ReturnType, Timestamp, Value,
         ValueType, Vector,
     };
-    use std::{borrow::Borrow, collections::HashSet, iter::zip, path::PathBuf};
+    use std::{
+        borrow::Borrow,
+        collections::HashSet,
+        iter::zip,
+        path::{Path, PathBuf},
+    };
 
     fn create_stream_helper(
         conn: &mut Connection,
@@ -902,6 +909,89 @@ mod tests {
         }
 
         assert_eq!(i, 4);
+    }
+
+    #[test]
+    fn test_e2e_get_stream_names() {
+        set_up_dirs!(dirs, "db");
+        let mut conn = Connection::new(dirs[0].clone()).unwrap();
+
+        let stream_names = vec![
+            r#"stream1{matcher="a"}"#,
+            r#"stream1{matcher="b"}"#,
+            r#"stream2{matcher="a"}"#,
+            r#"stream2{matcher="b"}"#,
+        ];
+
+        for stream in &stream_names {
+            let mut inserter = create_stream_helper(&mut conn, stream, ValueType::Integer64);
+            inserter.flush().unwrap();
+        }
+
+        let all_string_names: Vec<String> = conn
+            .get_all_stream_names()
+            .unwrap()
+            .into_iter()
+            .map(|x| x.1)
+            .collect();
+        assert!(all_string_names.len() == 4);
+        assert!(all_string_names.contains(&String::from(r#"stream1{matcher="a"}"#)));
+        assert!(all_string_names.contains(&String::from(r#"stream1{matcher="b"}"#)));
+        assert!(all_string_names.contains(&String::from(r#"stream2{matcher="a"}"#)));
+        assert!(all_string_names.contains(&String::from(r#"stream2{matcher="b"}"#)));
+
+        let matching_string_names = conn.get_matching_stream_names(r#"stream1"#).unwrap();
+
+        assert!(matching_string_names.len() == 2);
+        assert!(matching_string_names.contains(&String::from(r#"stream1{matcher="a"}"#)));
+        assert!(matching_string_names.contains(&String::from(r#"stream1{matcher="b"}"#)));
+    }
+
+    #[test]
+    fn test_e2e_delete_streams() {
+        set_up_dirs!(dirs, "db");
+        let mut conn = Connection::new(dirs[0].clone()).unwrap();
+
+        let deleted_stream_names = vec![r#"stream1{matcher="a"}"#, r#"stream1{matcher="b"}"#];
+        let remaining_stream_names = vec![r#"stream2{matcher="a"}"#, r#"stream2{matcher="b"}"#];
+
+        for stream in &deleted_stream_names {
+            let mut inserter = create_stream_helper(&mut conn, stream, ValueType::Integer64);
+            inserter.flush().unwrap();
+        }
+        for stream in &remaining_stream_names {
+            let mut inserter = create_stream_helper(&mut conn, stream, ValueType::Integer64);
+            inserter.flush().unwrap();
+        }
+
+        let streams_before = conn.get_all_streams().unwrap();
+        conn.delete_stream(r#"stream1"#).unwrap();
+
+        // Check correct streams were deleted from indexer
+        let streams_after = conn.get_all_streams().unwrap();
+        assert!(streams_after.len() == remaining_stream_names.len());
+        for stream in &deleted_stream_names {
+            assert!(!conn.check_stream_exists(stream).unwrap());
+        }
+        for stream in &remaining_stream_names {
+            assert!(conn.check_stream_exists(stream).unwrap());
+        }
+
+        // Check correct streams were deleted physically
+        let stream_ids_after: Vec<Uuid> = streams_after.iter().map(|x| x.0).collect();
+        for (stream_id, _, _) in streams_before {
+            let path = format!(
+                "{}/{}",
+                dirs[0].clone().into_os_string().into_string().unwrap(),
+                stream_id
+            );
+            println!("{}", path);
+            if stream_ids_after.contains(&stream_id) {
+                assert!(Path::new(&path).exists());
+            } else {
+                assert!(!Path::new(&path).exists());
+            }
+        }
     }
 
     fn execution_test_helper(

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -941,7 +941,6 @@ mod tests {
         assert!(all_string_names.contains(&String::from(r#"stream2{matcher="b"}"#)));
 
         let matching_string_names = conn.get_matching_stream_names(r#"stream1"#).unwrap();
-
         assert!(matching_string_names.len() == 2);
         assert!(matching_string_names.contains(&String::from(r#"stream1{matcher="a"}"#)));
         assert!(matching_string_names.contains(&String::from(r#"stream1{matcher="b"}"#)));

--- a/tachyon_core/src/lib.rs
+++ b/tachyon_core/src/lib.rs
@@ -433,6 +433,33 @@ impl Connection {
             .get_stream_ids(selector.name.as_ref().unwrap(), &selector.matchers)
     }
 
+    pub fn get_matching_stream_names(
+        &self,
+        stream: impl AsRef<str>,
+    ) -> Result<Vec<String>, TachyonErr> {
+        let selector = self.parse_stream_for_insert(&stream)?;
+
+        let stream_ids = self.get_stream_ids_for_selector(&selector);
+        let all_stream_names = self.get_all_stream_names()?;
+
+        let mut stream_names: Vec<String> = Vec::new();
+        for (stream_id, stream_name) in all_stream_names {
+            if stream_ids.contains(&stream_id) {
+                stream_names.push(stream_name);
+            }
+        }
+
+        if stream_names.is_empty() {
+            return Err(TachyonErr::ConnectionErr(
+                ConnectionErr::MissingStreamDeletionErr {
+                    stream: stream.as_ref().to_string(),
+                },
+            ));
+        }
+
+        Ok(stream_names)
+    }
+
     pub fn create_stream(
         &mut self,
         stream: impl AsRef<str>,
@@ -441,9 +468,11 @@ impl Connection {
         let selector = self.parse_stream_for_insert(&stream)?;
 
         if !self.get_stream_ids_for_selector(&selector).is_empty() {
-            return Err(TachyonErr::ConnectionErr(ConnectionErr::StreamExistsErr {
-                stream: stream.as_ref().to_string(),
-            }));
+            return Err(TachyonErr::ConnectionErr(
+                ConnectionErr::ExistingStreamCreationErr {
+                    stream: stream.as_ref().to_string(),
+                },
+            ));
         }
 
         let stream_id = self
@@ -464,8 +493,34 @@ impl Connection {
         Ok(())
     }
 
-    pub fn delete_stream(&mut self, stream: impl AsRef<str>) {
-        todo!("Not deleting stream {:?}", stream.as_ref());
+    pub fn delete_stream(&mut self, stream: impl AsRef<str>) -> Result<(), TachyonErr> {
+        let selector = self.parse_stream_for_insert(&stream)?;
+
+        let stream_ids = self.get_stream_ids_for_selector(&selector);
+        if self.get_stream_ids_for_selector(&selector).is_empty() {
+            return Err(TachyonErr::ConnectionErr(
+                ConnectionErr::MissingStreamDeletionErr {
+                    stream: stream.as_ref().to_string(),
+                },
+            ));
+        }
+
+        // Delete physical files
+        for stream_id in &stream_ids {
+            self.writer.borrow_mut().delete_stream(*stream_id)?;
+        }
+
+        // Delete from indexer
+        self.indexer
+            .borrow_mut()
+            .delete_stream_ids(stream_ids)
+            .map_err(|_| {
+                TachyonErr::ConnectionErr(ConnectionErr::StreamDeletionErr {
+                    stream: stream.as_ref().to_string(),
+                })
+            })?;
+
+        Ok(())
     }
 
     pub fn check_stream_exists(&self, stream: impl AsRef<str>) -> Result<bool, TachyonErr> {
@@ -478,6 +533,13 @@ impl Connection {
         self.indexer
             .borrow()
             .get_all_streams()
+            .map_err(|_| TachyonErr::ConnectionErr(ConnectionErr::GetStreamsErr))
+    }
+
+    pub fn get_all_stream_names(&self) -> Result<Vec<(Uuid, String)>, TachyonErr> {
+        self.indexer
+            .borrow()
+            .get_all_stream_names()
             .map_err(|_| TachyonErr::ConnectionErr(ConnectionErr::GetStreamsErr))
     }
 

--- a/tachyon_core/src/query/indexer.rs
+++ b/tachyon_core/src/query/indexer.rs
@@ -716,7 +716,7 @@ mod tests {
     use crate::ValueType;
     use promql_parser::label::{MatchOp, Matcher, Matchers};
     use std::collections::HashSet;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use uuid::Uuid;
 
     #[test]
@@ -820,11 +820,8 @@ mod tests {
         indexer.drop_store().unwrap();
     }
 
-    #[test]
-    fn test_get_value_type_for_stream() {
-        set_up_dirs!(dirs, "db");
-
-        let mut indexer = Indexer::new(dirs[0].clone()).unwrap();
+    fn indexer_test_helper(root_dir: impl AsRef<Path>) -> ((Uuid, Uuid, Uuid), Indexer) {
+        let mut indexer = Indexer::new(root_dir).unwrap();
         indexer.drop_store().unwrap();
         indexer.create_store().unwrap();
 
@@ -854,6 +851,14 @@ mod tests {
         let s3id = indexer
             .insert_new_id(stream3, &matchers3, stream_value_type_3)
             .unwrap();
+
+        ((s1id, s2id, s3id), indexer)
+    }
+
+    #[test]
+    fn test_get_value_type_for_stream() {
+        set_up_dirs!(dirs, "db");
+        let ((s1id, s2id, s3id), indexer) = indexer_test_helper(dirs[0].clone());
 
         assert_eq!(
             indexer.get_stream_value_type(s1id),
@@ -872,37 +877,7 @@ mod tests {
     #[test]
     fn test_get_all_streams() {
         set_up_dirs!(dirs, "db");
-
-        let mut indexer = Indexer::new(dirs[0].clone()).unwrap();
-        indexer.drop_store().unwrap();
-        indexer.create_store().unwrap();
-
-        let (stream1, matchers1, stream_value_type_1) = (
-            "str1",
-            Matchers::new(vec![Matcher::new(MatchOp::Equal, "a", "b")]),
-            ValueType::UInteger64,
-        );
-        let s1id = indexer
-            .insert_new_id(stream1, &matchers1, stream_value_type_1)
-            .unwrap();
-
-        let (stream2, matchers2, stream_value_type_2) = (
-            "str2",
-            Matchers::new(vec![Matcher::new(MatchOp::Equal, "c", "d")]),
-            ValueType::Integer64,
-        );
-        let s2id = indexer
-            .insert_new_id(stream2, &matchers2, stream_value_type_2)
-            .unwrap();
-
-        let (stream3, matchers3, stream_value_type_3) = (
-            "str3",
-            Matchers::new(vec![Matcher::new(MatchOp::Equal, "e", "f")]),
-            ValueType::Float64,
-        );
-        let s3id = indexer
-            .insert_new_id(stream3, &matchers3, stream_value_type_3)
-            .unwrap();
+        let ((s1id, s2id, s3id), indexer) = indexer_test_helper(dirs[0].clone());
 
         let all_streams = indexer.get_all_streams().unwrap();
         assert_eq!(all_streams.len(), 3);
@@ -922,5 +897,61 @@ mod tests {
         assert_eq!(all_streams[0].2, ValueType::UInteger64);
         assert_eq!(all_streams[1].2, ValueType::Integer64);
         assert_eq!(all_streams[2].2, ValueType::Float64);
+    }
+
+    #[test]
+    fn test_get_all_stream_names() {
+        set_up_dirs!(dirs, "db");
+        let ((s1id, s2id, s3id), indexer) = indexer_test_helper(dirs[0].clone());
+
+        let all_stream_names = indexer.get_all_stream_names().unwrap();
+        assert_eq!(all_stream_names.len(), 3);
+
+        assert_eq!(all_stream_names[0].0, s1id);
+        assert_eq!(all_stream_names[1].0, s2id);
+        assert_eq!(all_stream_names[2].0, s3id);
+
+        assert_eq!(all_stream_names[0].1, r#"str1{a="b"}"#);
+        assert_eq!(all_stream_names[1].1, r#"str2{c="d"}"#);
+        assert_eq!(all_stream_names[2].1, r#"str3{e="f"}"#);
+    }
+
+    #[test]
+    fn test_delete_stream_ids() {
+        set_up_dirs!(dirs, "db");
+        let ((s1id, s2id, s3id), mut indexer) = indexer_test_helper(dirs[0].clone());
+
+        // Add dummy data to "id to file" table
+        indexer
+            .insert_new_file(s1id, Path::new("a"), 10, Some(20))
+            .unwrap();
+        indexer
+            .insert_new_file(s2id, Path::new("b"), 10, Some(20))
+            .unwrap();
+        indexer
+            .insert_new_file(s3id, Path::new("c"), 10, Some(20))
+            .unwrap();
+
+        // Delete stream ids
+        let mut delete_ids = HashSet::new();
+        delete_ids.insert(s1id);
+        delete_ids.insert(s2id);
+        indexer.delete_stream_ids(delete_ids).unwrap();
+
+        // Check "stream to ids" table
+        let all_stream_names = indexer.get_all_stream_names().unwrap();
+        assert_eq!(all_stream_names.len(), 1);
+        assert_eq!(all_stream_names[0].0, s3id);
+        assert_eq!(all_stream_names[0].1, r#"str3{e="f"}"#);
+
+        // Check "id to file" table
+        assert_eq!(indexer.get_required_files(s1id, 0, 30).unwrap().len(), 0);
+        assert_eq!(indexer.get_required_files(s2id, 0, 30).unwrap().len(), 0);
+        assert_eq!(indexer.get_required_files(s3id, 0, 30).unwrap().len(), 1);
+
+        // Check "id to value type" table
+        assert!(indexer.get_stream_value_type(s1id).is_none());
+        assert!(indexer.get_stream_value_type(s2id).is_none());
+        assert!(indexer.get_stream_value_type(s3id).is_some());
     }
 }

--- a/tachyon_core/src/query/indexer.rs
+++ b/tachyon_core/src/query/indexer.rs
@@ -1,6 +1,6 @@
 use crate::error::IndexerErr;
 use crate::{StreamSummaryType, Timestamp, ValueType};
-use promql_parser::label::Matchers;
+use promql_parser::label::{MatchOp, Matcher, Matchers};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -10,6 +10,7 @@ trait IndexerStore {
     fn drop_store(&mut self) -> Result<(), IndexerErr>;
 
     fn get_all_streams(&self) -> Result<Vec<StreamSummaryType>, IndexerErr>;
+    fn get_all_stream_names(&self) -> Result<Vec<(Uuid, String)>, IndexerErr>;
     fn get_value_type_for_stream_id(&self, stream_id: Uuid) -> Option<ValueType>;
 
     fn insert_new_id(
@@ -48,6 +49,7 @@ trait IndexerStore {
     ) -> Result<Vec<PathBuf>, IndexerErr>;
     fn get_open_files_for_stream_id(&self, stream_id: Uuid) -> Result<Vec<PathBuf>, IndexerErr>;
     fn get_max_timestamp(&self, stream_id: Uuid) -> Result<Option<Timestamp>, IndexerErr>;
+    fn delete_stream_ids(&mut self, delete_ids: HashSet<Uuid>) -> Result<(), IndexerErr>;
 }
 
 mod sqlite {
@@ -437,6 +439,29 @@ mod sqlite {
             Ok(streams)
         }
 
+        fn get_all_stream_names(&self) -> Result<Vec<(Uuid, String)>, IndexerErr> {
+            let streams = self.get_all_streams()?;
+            let mut stream_names: Vec<(Uuid, String)> = Vec::new();
+
+            for (stream_id, matcher_strings, _) in streams {
+                let mut stream_name = String::new();
+
+                let mut matchers: Vec<Matcher> = Vec::new();
+                for matcher in matcher_strings {
+                    if matcher.0 == Self::SQLITE_STREAM_NAME_COLUMN {
+                        stream_name = matcher.1;
+                    } else {
+                        matchers.push(Matcher::new(MatchOp::Equal, &matcher.0, &matcher.1));
+                    }
+                }
+                let matchers = Matchers::new(matchers);
+
+                stream_names.push((stream_id, format!("{}{{{}}}", stream_name, matchers)));
+            }
+
+            Ok(stream_names)
+        }
+
         fn get_open_files_for_stream_id(
             &self,
             stream_id: Uuid,
@@ -473,6 +498,91 @@ mod sqlite {
                 stmt.query_row([stream_id], |row| row.get::<_, Option<u64>>(0))?;
 
             Ok(max_value)
+        }
+
+        fn delete_stream_ids(&mut self, delete_ids: HashSet<Uuid>) -> Result<(), IndexerErr> {
+            // Read stream to ids table
+            let stream_to_ids = {
+                let mut stmt = self.conn.prepare_cached(&format!(
+                    "SELECT name, value, ids FROM {}",
+                    Self::SQLITE_STREAM_TO_IDS_TABLE
+                ))?;
+
+                // SAFETY: the row.get calls will only fail if we generated the table wrong, which is bad
+                let rows = stmt.query_map((), |row| {
+                    Ok((
+                        row.get::<usize, String>(0)
+                            .expect("Stream to ID table: row not valid at idx 0."),
+                        row.get::<usize, String>(1)
+                            .expect("Stream to ID table: row not valid at idx 1."),
+                        row.get::<usize, String>(2)
+                            .expect("Stream to ID table: row not valid at idx 2."),
+                    ))
+                })?;
+
+                let mut stream_to_ids = Vec::new();
+                for item in rows {
+                    // SAFETY: this will always be Ok based on implementation of .query_map above
+                    stream_to_ids.push(item.unwrap());
+                }
+                stream_to_ids
+            };
+
+            let transaction: rusqlite::Transaction<'_> = self.conn.transaction()?;
+
+            // Remove ids from "stream to ids" table
+            let mut delete_ids_stmt = transaction.prepare_cached(&format!(
+                "DELETE FROM {} WHERE name = ? AND value = ?",
+                Self::SQLITE_STREAM_TO_IDS_TABLE
+            ))?;
+            let mut update_ids_stmt = transaction.prepare_cached(&format!(
+                "UPDATE {} SET ids = ? WHERE name = ? AND value = ?",
+                Self::SQLITE_STREAM_TO_IDS_TABLE
+            ))?;
+
+            for (name, value, stream_ids_str) in stream_to_ids {
+                // SAFETY: the string is from our database, it should always convert properly
+                let stream_ids: HashSet<Uuid> = serde_json::from_str(&stream_ids_str)
+                    .expect("Stream to ID table: ID column not properly formatted.");
+                let new_stream_ids = &stream_ids - &delete_ids;
+
+                if new_stream_ids.is_empty() {
+                    delete_ids_stmt.execute((name, value))?;
+                } else if new_stream_ids.len() < stream_ids.len() {
+                    // SAFETY: should always be able to convert HashSet to string
+                    let stream_ids_str = serde_json::to_string(&new_stream_ids)
+                        .expect("Failed to serialize stream_ids to string.");
+                    update_ids_stmt.execute((stream_ids_str, name, value))?;
+                }
+            }
+
+            drop(delete_ids_stmt);
+            drop(update_ids_stmt);
+
+            // Remove ids from "id to filename" and "id to value type" tables
+            let mut delete_filenames_stmt = transaction.prepare_cached(&format!(
+                "DELETE FROM {} WHERE id = ?",
+                Self::SQLITE_ID_TO_FILENAME_TABLE
+            ))?;
+            let mut delete_value_types_stmt = transaction.prepare_cached(&format!(
+                "DELETE FROM {} WHERE id = ?",
+                Self::SQLITE_ID_TO_VALUE_TYPE_TABLE
+            ))?;
+
+            for stream_id in delete_ids {
+                delete_filenames_stmt.execute([stream_id])?;
+                // SAFETY: should always be able to convert Uuid to String
+                delete_value_types_stmt.execute([
+                    serde_json::to_string(&stream_id).expect("Failed to serialize new_id.")
+                ])?;
+            }
+
+            drop(delete_filenames_stmt);
+            drop(delete_value_types_stmt);
+
+            transaction.commit()?;
+
+            Ok(())
         }
     }
 }
@@ -535,6 +645,10 @@ impl Indexer {
         self.store.get_all_streams()
     }
 
+    pub fn get_all_stream_names(&self) -> Result<Vec<(Uuid, String)>, IndexerErr> {
+        self.store.get_all_stream_names()
+    }
+
     pub fn get_stream_ids(&self, stream: &str, matchers: &Matchers) -> HashSet<Uuid> {
         let mut id_lists = self.store.get_stream_and_matcher_ids(stream, matchers);
         self.compute_intersection(&mut id_lists)
@@ -588,6 +702,10 @@ impl Indexer {
         stream_id: Uuid,
     ) -> Result<Vec<PathBuf>, IndexerErr> {
         self.store.get_open_files_for_stream_id(stream_id)
+    }
+
+    pub fn delete_stream_ids(&mut self, delete_ids: HashSet<Uuid>) -> Result<(), IndexerErr> {
+        self.store.delete_stream_ids(delete_ids)
     }
 }
 

--- a/tachyon_core/src/storage/writer/in_memory_writer.rs
+++ b/tachyon_core/src/storage/writer/in_memory_writer.rs
@@ -115,6 +115,14 @@ impl Writer for InMemoryWriter {
         Ok(())
     }
 
+    fn delete_stream(&self, stream_id: Uuid) -> Result<(), WriterErr> {
+        let stream = self.root.join(stream_id.to_string());
+        if stream.exists() {
+            fs::remove_dir_all(stream)?;
+        }
+        Ok(())
+    }
+
     fn flush_all(&mut self) -> Result<(), WriterErr> {
         for (stream_id, file) in self.open_data_files.iter_mut() {
             let file_path = InMemoryWriter::create_virtual_file_path(*stream_id, file);

--- a/tachyon_core/src/storage/writer/in_memory_writer.rs
+++ b/tachyon_core/src/storage/writer/in_memory_writer.rs
@@ -115,12 +115,8 @@ impl Writer for InMemoryWriter {
         Ok(())
     }
 
-    fn delete_stream(&self, stream_id: Uuid) -> Result<(), WriterErr> {
-        let stream = self.root.join(stream_id.to_string());
-        if stream.exists() {
-            fs::remove_dir_all(stream)?;
-        }
-        Ok(())
+    fn delete_stream(&self, _stream_id: Uuid) -> Result<(), WriterErr> {
+        panic!("Not implemented.");
     }
 
     fn flush_all(&mut self) -> Result<(), WriterErr> {

--- a/tachyon_core/src/storage/writer/mod.rs
+++ b/tachyon_core/src/storage/writer/mod.rs
@@ -20,4 +20,5 @@ pub trait Writer {
     ) -> Result<(), WriterErr>;
     fn flush_all(&mut self) -> Result<(), WriterErr>;
     fn create_stream(&self, stream_id: Uuid) -> Result<(), WriterErr>;
+    fn delete_stream(&self, stream_id: Uuid) -> Result<(), WriterErr>;
 }

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -553,4 +553,35 @@ mod tests {
             assert!(result.is_err(), "Expected an error, but got {:?}", result);
         }
     }
+
+    #[test]
+    fn test_delete_stream_files() {
+        set_up_dirs!(dirs, "db");
+        let stream_id = Uuid::new_v4();
+
+        let indexer = Rc::new(RefCell::new(Indexer::new(dirs[0].clone()).unwrap()));
+        indexer.borrow_mut().create_store().unwrap();
+        let batch_size: u64 = 12801;
+
+        {
+            let mut writer = PersistentWriter::new(dirs[0].clone(), indexer.clone(), Version(0));
+            writer.create_stream(stream_id).unwrap();
+            for i in 0..batch_size {
+                let ts = i as Timestamp;
+                let v = (i * 1000).into();
+                writer
+                    .write(stream_id, ts, v, ValueType::UInteger64)
+                    .unwrap();
+            }
+        }
+
+        assert!(fs::exists(dirs[0].join(stream_id.to_string())).unwrap());
+
+        {
+            let writer = PersistentWriter::new(dirs[0].clone(), indexer.clone(), Version(0));
+            writer.delete_stream(stream_id).unwrap();
+        }
+
+        assert!(!fs::exists(dirs[0].join(stream_id.to_string())).unwrap());
+    }
 }

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -555,7 +555,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_stream_files() {
+    fn test_delete_stream() {
         set_up_dirs!(dirs, "db");
         let stream_id = Uuid::new_v4();
 

--- a/tachyon_core/src/storage/writer/persistent_writer.rs
+++ b/tachyon_core/src/storage/writer/persistent_writer.rs
@@ -148,6 +148,14 @@ impl Writer for PersistentWriter {
         }
         Ok(())
     }
+
+    fn delete_stream(&self, stream_id: Uuid) -> Result<(), WriterErr> {
+        let stream = self.root.join(stream_id.to_string());
+        if stream.exists() {
+            fs::remove_dir_all(stream)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add command to delete streams: `.delete [stream]`

![image](https://github.com/user-attachments/assets/0a4cf511-07fe-4ef8-b6e1-1b781114987c)

- Yes/no confirmation prompt that prints which streams get deleted

- Deletes physical DB files and removes relevant ids from all three indexer tables

Other notes:

- To print the streams being deleted, implemented a helper function `get_all_stream_names()` which maps stream IDs to the original stream strings (i.e. stream + matchers). Unfortunately we don't actually store those original strings anywhere in the indexer so it has to reconstruct them.

- No concurrency/locking. Maybe we could wait for a exclusive lock on all physical files before deleting.